### PR TITLE
Remove google analytics and tracking calls

### DIFF
--- a/src/popup/app.component.ts
+++ b/src/popup/app.component.ts
@@ -7,7 +7,6 @@ import {
     ToasterContainerComponent,
     ToasterService,
 } from 'angular2-toaster';
-import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 import swal from 'sweetalert';
 
 import {
@@ -61,7 +60,7 @@ export class AppComponent implements OnInit {
 
     private lastActivity: number = null;
 
-    constructor(private angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics, private analytics: Angulartics2,
+    constructor(private analytics: Angulartics2,
         private toasterService: ToasterService, private storageService: StorageService,
         private broadcasterService: BroadcasterService, private authService: AuthService,
         private i18nService: I18nService, private router: Router,
@@ -116,10 +115,11 @@ export class AppComponent implements OnInit {
                     this.showToast(msg);
                 });
             } else if (msg.command === 'analyticsEventTrack') {
-                this.analytics.eventTrack.next({
+                // TODO: re-enable tracking or remove
+                /*this.analytics.eventTrack.next({
                     action: msg.action,
                     properties: { label: msg.label },
-                });
+                });*/
             } else if (msg.command === 'reloadProcess') {
                 const windowReload = this.platformUtilsService.isSafari() ||
                     this.platformUtilsService.isFirefox() || this.platformUtilsService.isOpera();

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -4,7 +4,6 @@ import 'zone.js/dist/zone';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ToasterModule } from 'angular2-toaster';
 import { Angulartics2Module } from 'angulartics2';
-import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -71,8 +70,6 @@ import localeFr from '@angular/common/locales/fr';
 registerLocaleData(localeEnGb, 'en-GB');
 registerLocaleData(localeFr, 'fr');
 
-// TODO: remove google tracking
-
 @NgModule({
     imports: [
         BrowserModule,
@@ -80,7 +77,7 @@ registerLocaleData(localeFr, 'fr');
         FormsModule,
         AppRoutingModule,
         ServicesModule,
-        Angulartics2Module.forRoot([Angulartics2GoogleAnalytics], {
+        Angulartics2Module.forRoot([], {
             pageTracking: {
                 clearQueryParams: true,
             },

--- a/src/services/browserPlatformUtils.service.ts
+++ b/src/services/browserPlatformUtils.service.ts
@@ -6,7 +6,7 @@ import { DeviceType } from 'jslib/enums/deviceType';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 
-import { AnalyticsIds } from 'jslib/misc/analytics';
+// import { AnalyticsIds } from 'jslib/misc/analytics';
 
 const DialogPromiseExpiration = 600000; // 10 minutes
 
@@ -80,13 +80,15 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
         return false;
     }
 
+    // TODO: re-enable tracking or remove
     analyticsId(): string {
-        if (this.analyticsIdCache) {
+        /*if (this.analyticsIdCache) {
             return this.analyticsIdCache;
         }
 
         this.analyticsIdCache = (AnalyticsIds as any)[this.getDevice()];
-        return this.analyticsIdCache;
+        return this.analyticsIdCache;*/
+        return;
     }
 
     async isViewOpen(): Promise<boolean> {
@@ -162,6 +164,7 @@ export default class BrowserPlatformUtilsService implements PlatformUtilsService
     }
 
     eventTrack(action: string, label?: string, options?: any) {
+        // FIXME: the service is currently disabled
         this.messagingService.send('analyticsEventTrack', {
             action: action,
             label: label,


### PR DESCRIPTION
Tracking was already disabled since this [commit](https://github.com/bitwarden/jslib/commit/f4c4f2802637f775c3bfba2ef4109350bc842b8f#diff-b351b37af83ee6f5ef2ac51a405511e9)
This PR removes useless instance of google analytics and calls to tracking.