### PR TITLE
chore: Minimize bundler for production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -146,7 +146,7 @@ const config = {
         'notification/bar': './src/notification/bar.js',
     },
     optimization: {
-        minimize: false,
+        minimize: ENV === 'production',
         splitChunks: {
             cacheGroups: {
                 commons: {


### PR DESCRIPTION
The production bundler wasn't minimized, making `popup/vendor.js` too heavy to pass the firefox extension validation.