### PR TITLE
chore: Add travis conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+node_js:
+  - '8'
+cache:
+  npm: true
+  directories:
+    - node_modules
+before_install:
+  - npm i -g npm@6.4.1
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb some time to start
+script:
+  - npm run build
+  - npm run lint
+  - npm run test


### PR DESCRIPTION
Add travis conf file for CI. The specificity here is the use of karma for the unit tests, which run an actual browser. It is thus necessary to enable a GUI as specified in the [doc](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui)