### PR TITLE
chore: Fix travis conf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: node_js
 node_js:
   - '8'
+services:
+  - xvfb
 cache:
   npm: true
   directories:
     - node_modules
 before_install:
   - npm i -g npm@6.4.1
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3 # give xvfb some time to start
 script:
   - npm run build
   - npm run lint


### PR DESCRIPTION
The xvfb configuration was the one recommended for Ubuntu trusty, while we currently are on Ubuntu xenial : https://docs.travis-ci.com/user/gui-and-headless-browsers/