### PR TITLE
feat: Remove observe DOM timeout

### DIFF
--- a/src/content/notificationBar.ts
+++ b/src/content/notificationBar.ts
@@ -19,7 +19,6 @@ document.addEventListener('DOMContentLoaded', (event) => {
         'button[type="submit"]';
     let domObservationCollectTimeout: number = null;
     let collectIfNeededTimeout: number = null;
-    let observeDomTimeout: number = null;
     const inIframe = isInIframe();
     let notificationBarData = null;
     const isSafari = (typeof safari !== 'undefined') && navigator.userAgent.indexOf(' Safari/') !== -1 &&
@@ -127,6 +126,10 @@ document.addEventListener('DOMContentLoaded', (event) => {
         }
     }
 
+    /**
+     * observeDom watches changes in the DOM and starts a new details page collect
+     * if a new form is found.
+     */
     function observeDom() {
         const bodies = document.querySelectorAll('body');
         if (bodies && bodies.length > 0) {
@@ -174,7 +177,6 @@ document.addEventListener('DOMContentLoaded', (event) => {
                     if (domObservationCollectTimeout != null) {
                         window.clearTimeout(domObservationCollectTimeout);
                     }
-
                     domObservationCollectTimeout = window.setTimeout(collect, 1000);
                 }
             });
@@ -198,11 +200,8 @@ document.addEventListener('DOMContentLoaded', (event) => {
                 observer = null;
             }
             collect();
-
-            if (observeDomTimeout != null) {
-                window.clearTimeout(observeDomTimeout);
-            }
-            observeDomTimeout = window.setTimeout(observeDom, 1000);
+            // The DOM might change during the collect: watch the DOM body for changes
+            observeDom();
         }
 
         if (collectIfNeededTimeout != null) {
@@ -357,6 +356,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
                 };
                 if (login.username != null && login.username !== '' &&
                     login.password != null && login.password !== '') {
+
                     if (!form) {
                         // This happens when the submit button was found outside of the form
                         form = formData[i].formEl;

--- a/src/content/notificationBar.ts
+++ b/src/content/notificationBar.ts
@@ -200,7 +200,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
                 observer = null;
             }
             collect();
-            // The DOM might change during the collect: watch the DOM body for changes
+            // The DOM might change during the collect: watch the DOM body for changes.
+            // Note: a setTimeout was present here, apparently related to the autofill:
+            // https://github.com/bitwarden/browser/commit/d19fcd6e4ccf062b595c2823267ffd32fd8e5a3d
             observeDom();
         }
 


### PR DESCRIPTION
A DOM change could not be seen if it occured between the collect and the observe DOM timeout end. This was causing some save login notification not showing, especially with slow connection.
I reproduced (not systematically) the issue on trainline.fr with Firefox 71, after a first login/logout and another login in GPRS connectivity.

Note the original reason behind this timeout seems to be about the autofill: https://github.com/bitwarden/browser/commit/d19fcd6e4ccf062b595c2823267ffd32fd8e5a3d 