### PR TITLE
feat: Communicate version to cozy-password message

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -387,6 +387,12 @@ export default class RuntimeBackground {
                     await this.setDefaultSettings();
                 }
 
+                // Execute the content-script on all tabs in case cozy-passwords is waiting for an answer
+                const allTabs = await BrowserApi.getAllTabs();
+                for (const tab of allTabs) {
+                    chrome.tabs.executeScript(tab.id, { file: 'content/appInfo.js' });
+                }
+
                 this.analytics.ga('send', {
                     hitType: 'event',
                     eventAction: 'onInstalled ' + this.onInstalledReason,

--- a/src/browser/browserApi.ts
+++ b/src/browser/browserApi.ts
@@ -28,6 +28,10 @@ export class BrowserApi {
         });
     }
 
+    static async getAllTabs(): Promise<any[]> {
+        return await BrowserApi.tabsQuery({});
+    }
+
     static async getActiveTabs(): Promise<any[]> {
         return await BrowserApi.tabsQuery({
             active: true,

--- a/src/content/appInfo.ts
+++ b/src/content/appInfo.ts
@@ -1,0 +1,14 @@
+import { BrowserApi } from '../browser/browserApi';
+
+window.addEventListener('message', async (event) => {
+    if (event.data && event.data.message && event.data.message.source === 'cozy-passwords') {
+        const version = BrowserApi.getApplicationVersion();
+        const message = {
+            source: 'cozy-extension',
+            version: version,
+        };
+        window.postMessage({
+            message: message,
+        }, event.origin);
+    }
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,8 @@
       "js": [
         "content/autofill.js",
         "content/autofiller.js",
-        "content/notificationBar.js"
+        "content/notificationBar.js",
+        "content/appInfo.js"
       ],
       "matches": [
         "http://*/*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,6 +139,7 @@ const config = {
     entry: {
         'popup/main': './src/popup/main.ts',
         'background': './src/background.ts',
+        'content/appInfo': './src/content/appInfo.ts',
         'content/autofill': './src/content/autofill.js',
         'content/autofiller': './src/content/autofiller.ts',
         'content/notificationBar': './src/content/notificationBar.ts',


### PR DESCRIPTION
When the user arrives on the installation step in cozy-passwords, the app regularly sends `postMessage`, waiting for an answer from the extension. 
Once the extension is installed, it intercepts the message and answer back with its version.

See https://github.com/cozy/cozy-passwords/pull/2 