### PR TITLE
fix: Trim classes having whitespaces

### DIFF
--- a/src/content/autofill.js
+++ b/src/content/autofill.js
@@ -230,7 +230,7 @@
                     const formById = form.htmlID ? el.closest('#' + form.htmlID) : null;
                     let formByClass;
                     if (form.htmlClass) {
-                        const classSelector = form.htmlClass.replace(/ /g,'.');
+                        const classSelector = form.htmlClass.trim().replace(/ /g,'.');
                         formByClass = el.closest('.' + classSelector);
                     }
                     return formById || formByClass;


### PR DESCRIPTION
A website might have badly-formed classes starting or finishing with spaces. In which case, the auto-fill would fail because of a bad selector, e.g. with trainline.fr