### PR TITLE
feat: Update synchronized_at on oauth client on each sync

### DIFF
--- a/overrides/jslib/src/services/sync.service.ts
+++ b/overrides/jslib/src/services/sync.service.ts
@@ -1,0 +1,63 @@
+import { ApiService } from 'jslib/abstractions/api.service';
+import { CipherService } from 'jslib/abstractions/cipher.service';
+import { CollectionService } from 'jslib/abstractions/collection.service';
+import { CryptoService } from 'jslib/abstractions/crypto.service';
+import { FolderService } from 'jslib/abstractions/folder.service';
+import { MessagingService } from 'jslib/abstractions/messaging.service';
+import { SettingsService } from 'jslib/abstractions/settings.service';
+import { StorageService } from 'jslib/abstractions/storage.service';
+import { UserService } from 'jslib/abstractions/user.service';
+
+import { SyncService as BaseSyncService } from 'original-jslib/services/sync.service';
+import { CozyClientService } from '../../../../src/popup/services/cozyClient.service';
+
+const Keys = {
+    lastSyncPrefix: 'lastSync_',
+};
+
+export class SyncService extends BaseSyncService {
+    // We need to store these two service instances here because in the extended
+    // class they are private, meaning we can't access this.userService or
+    // this.storageService otherwise
+    /* tslint:disable-next-line */
+    private _userService: UserService;
+    /* tslint:disable-next-line */
+    private _storageService: StorageService;
+
+    constructor(
+        userService: UserService,
+        apiService: ApiService,
+        settingsService: SettingsService,
+        folderService: FolderService,
+        cipherService: CipherService,
+        cryptoService: CryptoService,
+        collectionService: CollectionService,
+        storageService: StorageService,
+        messagingService: MessagingService,
+        logoutCallback: (expired: boolean) => Promise<void>,
+        private cozyClientService: () => CozyClientService,
+    ) {
+            super(
+                userService,
+                apiService,
+                settingsService,
+                folderService,
+                cipherService,
+                cryptoService,
+                collectionService,
+                storageService,
+                messagingService,
+                logoutCallback,
+            );
+
+            this._userService = userService;
+            this._storageService = storageService;
+    }
+
+    async setLastSync(date: Date): Promise<any> {
+        await super.setLastSync(date);
+
+        const cozyClientService = this.cozyClientService();
+        await cozyClientService.updateSynchronizedAt();
+    }
+}

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -14,7 +14,6 @@ import {
     LockService,
     PasswordGenerationService,
     SettingsService,
-    SyncService,
     TokenService,
     TotpService,
     UserService,
@@ -23,6 +22,7 @@ import { EventService } from 'jslib/services/event.service';
 import { ExportService } from 'jslib/services/export.service';
 import { NotificationsService } from 'jslib/services/notifications.service';
 import { SearchService } from 'jslib/services/search.service';
+import { SyncService } from 'jslib/services/sync.service';
 import { SystemService } from 'jslib/services/system.service';
 import { WebCryptoFunctionService } from 'jslib/services/webCryptoFunction.service';
 
@@ -172,7 +172,7 @@ export default class MainBackground {
             });
         this.syncService = new SyncService(this.userService, this.apiService, this.settingsService,
             this.folderService, this.cipherService, this.cryptoService, this.collectionService,
-            this.storageService, this.messagingService, async (expired: boolean) => await this.logout(expired));
+        this.storageService, this.messagingService, async (expired: boolean) => await this.logout(expired), () => this.cozyClientService);
         this.eventService = new EventService(this.storageService, this.apiService, this.userService,
             this.cipherService);
         this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.storageService);

--- a/src/popup/services/cozyClient.service.ts
+++ b/src/popup/services/cozyClient.service.ts
@@ -15,4 +15,17 @@ export class CozyClientService {
         const token = await this.apiService.getActiveBearerToken();
         return new CozyClient({ uri: uri, token: token });
     }
+
+    async updateSynchronizedAt() {
+        const client = await this.createClient();
+
+        try {
+            await client.getStackClient().fetchJSON('POST', '/settings/synchronized');
+        } catch (err) {
+            /* tslint:disable-next-line */
+            console.error('Error while updating cozy client\'s synchronized_at');
+            /* tslint:disable-next-line */
+            console.error(err);
+        }
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -170,7 +170,9 @@ const config = {
     resolve: {
         extensions: ['.ts', '.js', '.json'],
         alias: {
-            jslib: path.join(__dirname, 'jslib/src'),
+            'jslib/services/sync.service$': path.join(__dirname, 'overrides/jslib/src/services/sync.service.ts'),
+            'jslib': path.join(__dirname, 'jslib/src'),
+            'original-jslib': path.join(__dirname, 'jslib/src'),
             'cozy-client': path.join(__dirname, 'node_modules/cozy-client/dist/node')
         },
         symlinks: false,


### PR DESCRIPTION
We want to update the synchronized_at on the io.cozy.oauth.clients every
time the extension is synced. It enables us to show this information in
cozy-settings.

To achieve that, I added a SyncService class that extends the jslib's
one and overrides its `setLastSync` method to call the
/settings/synchronized stack route. This class is imported when the
original one is imported. The webpack configs replaces the original one
with the override.