### PR TITLE
fix: Don't override whole jslib file

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -22,9 +22,10 @@ import { EventService } from 'jslib/services/event.service';
 import { ExportService } from 'jslib/services/export.service';
 import { NotificationsService } from 'jslib/services/notifications.service';
 import { SearchService } from 'jslib/services/search.service';
-import { SyncService } from 'jslib/services/sync.service';
 import { SystemService } from 'jslib/services/system.service';
 import { WebCryptoFunctionService } from 'jslib/services/webCryptoFunction.service';
+
+import { SyncService } from '../popup/services/sync.service';
 
 import {
     ApiService as ApiServiceAbstraction,

--- a/src/popup/services/sync.service.ts
+++ b/src/popup/services/sync.service.ts
@@ -8,8 +8,9 @@ import { SettingsService } from 'jslib/abstractions/settings.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
-import { SyncService as BaseSyncService } from 'original-jslib/services/sync.service';
-import { CozyClientService } from '../../../../src/popup/services/cozyClient.service';
+import { SyncService as BaseSyncService } from 'jslib/services/sync.service';
+
+import { CozyClientService } from './cozyClient.service';
 
 const Keys = {
     lastSyncPrefix: 'lastSync_',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -170,9 +170,7 @@ const config = {
     resolve: {
         extensions: ['.ts', '.js', '.json'],
         alias: {
-            'jslib/services/sync.service$': path.join(__dirname, 'overrides/jslib/src/services/sync.service.ts'),
             'jslib': path.join(__dirname, 'jslib/src'),
-            'original-jslib': path.join(__dirname, 'jslib/src'),
             'cozy-client': path.join(__dirname, 'node_modules/cozy-client/dist/node')
         },
         symlinks: false,


### PR DESCRIPTION
When building for production, the alias used to override the
sync.service.ts file from the jslib was not resolved. A little research
showed that the problem is caused by the usage of the
AngularCompilerPlugin in the webpack config. But after reading the docs,
I was not able to fix the problem.

So the solution here is to not override the file, but to manually change
the import path in files were it's imported.