### PR TITLE
fix: clear token after others services in logout

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -307,7 +307,6 @@ export default class MainBackground {
         await Promise.all([
             this.eventService.clearEvents(),
             this.syncService.setLastSync(new Date(0)),
-            this.tokenService.clearToken(),
             this.cryptoService.clearKeys(),
             this.userService.clear(),
             this.settingsService.clear(userId),
@@ -317,6 +316,9 @@ export default class MainBackground {
             this.passwordGenerationService.clear(),
             this.lockService.clear(),
         ]);
+
+        // Clear token afterwards, as previous services might need it
+        await this.tokenService.clearToken();
 
         this.searchService.clearIndex();
         this.messagingService.send('doneLoggingOut', { expired: expired });


### PR DESCRIPTION
The logout notification was not working properly, failing with a `Token not found`.
This was because all the services cleanup were run in parallel, while some might need the token, which is being cleared during the process.
Therefore, we run the `clearToken` after all the services have finished to clear themselves.
