### PR TITLE
fix(home): Avoid signup link overflow on login button

### DIFF
--- a/src/popup/accounts/home.component.html
+++ b/src/popup/accounts/home.component.html
@@ -3,6 +3,6 @@
         <div class="logo-image"></div>
         <p class="lead text-center">{{'loginOrCreateNewAccount' | i18n}}</p>
         <a class="btn primary block" routerLink="/login"><b>{{'login' | i18n}}</b></a>
-        <a class="center-content" href="https://cozy.io">{{'notRegistered' | i18n}}</a>
+        <a class="signup-link" href="https://cozy.io">{{'notRegistered' | i18n}}</a>
     </div>
 </div>

--- a/src/popup/scss/pages.scss
+++ b/src/popup/scss/pages.scss
@@ -69,6 +69,12 @@ app-home {
             }
         }
     }
+
+    .signup-link {
+        display: block;
+        text-align: center;
+        margin-top: 32px;
+    }
 }
 
 body.body-sm, body.body-xs {


### PR DESCRIPTION
On the home page, the signup link styles make it overflow on the login button. So clicking on the login button actually opened a new browser tab on the cozy.io website.

![before-fix](https://user-images.githubusercontent.com/1606068/73180895-82eede80-4116-11ea-8ef4-60819ee5e6b5.png)

The `center-content` class' role is to... center content. Using it on this element is pretty weird. I just replaced it with a custom class that properly align the element without making it overflow its sibling.