### PR TITLE
feat: Remove oauth client on logout

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -27,6 +27,7 @@ import { SyncService } from '../popup/services/sync.service';
 import { ExportService } from '../services/export.service';
 
 import { ApiService } from '../services/api.service';
+import { AuthService } from '../services/auth.service';
 
 import {
     ApiService as ApiServiceAbstraction,
@@ -112,6 +113,7 @@ export default class MainBackground {
     analytics: Analytics;
     cozyClientService: CozyClientService;
     konnectorsService: KonnectorsService;
+    authService: AuthService;
 
     onUpdatedRan: boolean;
     onReplacedRan: boolean;
@@ -225,6 +227,19 @@ export default class MainBackground {
                 this.lockService);
             this.windowsBackground = new WindowsBackground(this);
         }
+
+        this.authService = new AuthService(
+            this.cryptoService,
+            this.apiService,
+            this.userService,
+            this.tokenService,
+            this.appIdService,
+            this.i18nService,
+            this.platformUtilsService,
+            this.messagingService,
+            true,
+            this.cozyClientService,
+        );
     }
 
     async bootstrap() {
@@ -318,7 +333,8 @@ export default class MainBackground {
             this.lockService.clear(),
         ]);
 
-        // Clear token afterwards, as previous services might need it
+        // Clear auth and token afterwards, as previous services might need it
+        await this.authService.clear();
         await this.tokenService.clearToken();
 
         this.searchService.clearIndex();

--- a/src/models/response/identityTokenResponse.ts
+++ b/src/models/response/identityTokenResponse.ts
@@ -1,0 +1,19 @@
+import {
+    IdentityTokenResponse as BaseIdentityTokenResponse,
+} from 'jslib/models/response/identityTokenResponse';
+
+/**
+ * We need to extend the jslib's IdentityTokenResponse to add the clientId and
+ * the registrationAccessToken properties returned by the stack. These
+ * properties are used to delete oauth client created by the stack on logout
+ */
+export class IdentityTokenResponse extends BaseIdentityTokenResponse {
+    clientId: string;
+    registrationAccessToken: string;
+
+    constructor(response: any) {
+        super(response);
+        this.clientId = response.client_id;
+        this.registrationAccessToken = response.registration_access_token;
+    }
+}

--- a/src/popup/services/cozyClient.service.ts
+++ b/src/popup/services/cozyClient.service.ts
@@ -3,17 +3,32 @@ import { ApiService } from 'jslib/abstractions/api.service';
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { TokenService } from 'jslib/abstractions/token.service';
 
+interface ICozyStackClient {
+    fetchJSON: (method: string, path: string) => Promise<any>;
+    fetch: (method: string, path: string, body: any, options: any) => Promise<any>;
+}
+
+interface ICozyClient {
+    getStackClient: () => ICozyStackClient;
+}
+
 export class CozyClientService {
+    protected instance: ICozyClient;
 
     constructor(protected environmentService: EnvironmentService,
         protected apiService: ApiService) {
     }
 
     async createClient() {
+        if (this.instance) {
+            return this.instance;
+        }
+
         const vaultUrl = this.environmentService.getWebVaultUrl();
         const uri = new URL(vaultUrl).origin; // Remove the /bitwarden part
         const token = await this.apiService.getActiveBearerToken();
-        return new CozyClient({ uri: uri, token: token });
+        this.instance = new CozyClient({ uri: uri, token: token });
+        return this.instance;
     }
 
     async updateSynchronizedAt() {
@@ -24,6 +39,28 @@ export class CozyClientService {
         } catch (err) {
             /* tslint:disable-next-line */
             console.error('Error while updating cozy client\'s synchronized_at');
+            /* tslint:disable-next-line */
+            console.error(err);
+        }
+    }
+
+    async deleteOAuthClient(clientId: string, registrationAccessToken: string) {
+        const client = await this.createClient();
+
+        try {
+            await client.getStackClient().fetch(
+                'DELETE',
+                '/auth/register/' + clientId,
+                undefined,
+                {
+                    headers: {
+                        Authorization: 'Bearer ' + registrationAccessToken,
+                    },
+                },
+            );
+        } catch (err) {
+            /* tslint:disable-next-line */
+            console.error('Error while deleting oauth client');
             /* tslint:disable-next-line */
             console.error(err);
         }

--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -46,7 +46,6 @@ import { UserService } from 'jslib/abstractions/user.service';
 import { AutofillService } from '../../services/abstractions/autofill.service';
 import BrowserMessagingService from '../../services/browserMessaging.service';
 
-import { AuthService } from 'jslib/services/auth.service';
 import { ConstantsService } from 'jslib/services/constants.service';
 import { SearchService } from 'jslib/services/search.service';
 import { StateService } from 'jslib/services/state.service';
@@ -55,6 +54,8 @@ import { Analytics } from 'jslib/misc/analytics';
 
 import { PopupSearchService } from './popup-search.service';
 import { PopupUtilsService } from './popup-utils.service';
+
+import { AuthService } from '../../services/auth.service';
 
 function getBgService<T>(service: string) {
     return (): T => {
@@ -70,11 +71,7 @@ export const cozyClientService = new CozyClientService(getBgService<EnvironmentS
 export const konnectorsService = new KonnectorsService(getBgService<CipherService>('cipherService')(),
     getBgService<StorageService>('storageService')(), getBgService<SettingsService>('settingsService')(),
     cozyClientService);
-export const authService = new AuthService(getBgService<CryptoService>('cryptoService')(),
-    getBgService<ApiService>('apiService')(), getBgService<UserService>('userService')(),
-    getBgService<TokenService>('tokenService')(), getBgService<AppIdService>('appIdService')(),
-    getBgService<I18nService>('i18nService')(), getBgService<PlatformUtilsService>('platformUtilsService')(),
-    messagingService);
+export const authService = getBgService<AuthService>('authService')();
 export const searchService = new PopupSearchService(getBgService<SearchService>('searchService')(),
     getBgService<CipherService>('cipherService')(), getBgService<PlatformUtilsService>('platformUtilsService')());
 

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -3,9 +3,10 @@ import { TokenService } from 'jslib/abstractions/token.service';
 import { DeviceType } from 'jslib/enums/deviceType';
 import { TokenRequest } from 'jslib/models/request/tokenRequest';
 import { ErrorResponse } from 'jslib/models/response/errorResponse';
-import { IdentityTokenResponse } from 'jslib/models/response/identityTokenResponse';
 import { IdentityTwoFactorResponse } from 'jslib/models/response/identityTwoFactorResponse';
 import { ApiService as BaseApiService } from 'jslib/services/api.service';
+
+import { IdentityTokenResponse } from '../models/response/identityTokenResponse';
 
 function getDeviceName(deviceType: DeviceType): string {
     switch (deviceType) {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,186 @@
+import { KdfType } from 'jslib/enums/kdfType';
+import { TwoFactorProviderType } from 'jslib/enums/twoFactorProviderType';
+
+import { AuthResult } from 'jslib/models/domain/authResult';
+import { SymmetricCryptoKey } from 'jslib/models/domain/symmetricCryptoKey';
+import { DeviceRequest } from 'jslib/models/request/deviceRequest';
+import { KeysRequest } from 'jslib/models/request/keysRequest';
+import { TokenRequest } from 'jslib/models/request/tokenRequest';
+import { IdentityTwoFactorResponse } from 'jslib/models/response/identityTwoFactorResponse';
+
+import { ApiService } from 'jslib/abstractions/api.service';
+import { AppIdService } from 'jslib/abstractions/appId.service';
+import { CryptoService } from 'jslib/abstractions/crypto.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { MessagingService } from 'jslib/abstractions/messaging.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { TokenService } from 'jslib/abstractions/token.service';
+import { UserService } from 'jslib/abstractions/user.service';
+
+import { AuthService as BaseAuthService } from 'jslib/services/auth.service';
+
+import { IdentityTokenResponse } from '../models/response/identityTokenResponse';
+
+import { CozyClientService } from '../popup/services/cozyClient.service';
+
+/**
+ * We extend the jslib's AuthService and override some methods (particularly
+ * the logInHelper) to store the clientId and registrationAccessToken returned
+ * by the stack on login. We also add a clear method that pass these infos
+ * to delete the created oauth client on logout.
+ */
+export class AuthService extends BaseAuthService {
+    email: string;
+    masterPasswordHash: string;
+    twoFactorProvidersData: Map<TwoFactorProviderType, { [key: string]: string; }>;
+    selectedTwoFactorProviderType: TwoFactorProviderType = null;
+    clientId: string;
+    registrationAccessToken: string;
+
+    /* tslint:disable-next-line */
+    private _key: SymmetricCryptoKey;
+    /* tslint:disable-next-line */
+    private _kdf: KdfType;
+    /* tslint:disable-next-line */
+    private _kdfIterations: number;
+
+    constructor(
+        /* tslint:disable-next-line */
+        private _cryptoService: CryptoService,
+        /* tslint:disable-next-line */
+        private _apiService: ApiService,
+        /* tslint:disable-next-line */
+        private _userService: UserService,
+        /* tslint:disable-next-line */
+        private _tokenService: TokenService,
+        /* tslint:disable-next-line */
+        private _appIdService: AppIdService,
+        /* tslint:disable-next-line */
+        private _i18nService: I18nService,
+        /* tslint:disable-next-line */
+        private _platformUtilsService: PlatformUtilsService,
+        /* tslint:disable-next-line */
+        private _messagingService: MessagingService,
+        /* tslint:disable-next-line */
+        private _setCryptoKeys = true,
+        /* tslint:disable-next-line */
+        private _cozyClientService: CozyClientService,
+    ) {
+        super(
+            _cryptoService,
+            _apiService,
+            _userService,
+            _tokenService,
+            _appIdService,
+            _i18nService,
+            _platformUtilsService,
+            _messagingService,
+            _setCryptoKeys,
+        );
+    }
+
+    clear(): Promise<void> {
+        return this._cozyClientService.deleteOAuthClient(
+            this.clientId,
+            this.registrationAccessToken,
+        );
+    }
+
+    async logIn(email: string, masterPassword: string): Promise<AuthResult> {
+        this.selectedTwoFactorProviderType = null;
+        const key = await this.makePreloginKey(masterPassword, email);
+        const hashedPassword = await this._cryptoService.hashPassword(masterPassword, key);
+        return await this._logInHelper(email, hashedPassword, key);
+    }
+
+    async logInTwoFactor(twoFactorProvider: TwoFactorProviderType, twoFactorToken: string,
+        remember?: boolean): Promise<AuthResult> {
+        return await this._logInHelper(this.email, this.masterPasswordHash, this._key, twoFactorProvider,
+            twoFactorToken, remember);
+    }
+
+    async logInComplete(email: string, masterPassword: string, twoFactorProvider: TwoFactorProviderType,
+        twoFactorToken: string, remember?: boolean): Promise<AuthResult> {
+        this.selectedTwoFactorProviderType = null;
+        const key = await this.makePreloginKey(masterPassword, email);
+        const hashedPassword = await this._cryptoService.hashPassword(masterPassword, key);
+        return await this._logInHelper(email, hashedPassword, key, twoFactorProvider, twoFactorToken, remember);
+    }
+
+    private async _logInHelper(email: string, hashedPassword: string, key: SymmetricCryptoKey,
+        twoFactorProvider?: TwoFactorProviderType, twoFactorToken?: string, remember?: boolean): Promise<AuthResult> {
+        const storedTwoFactorToken = await this._tokenService.getTwoFactorToken(email);
+        const appId = await this._appIdService.getAppId();
+        const deviceRequest = new DeviceRequest(appId, this._platformUtilsService);
+
+        let request: TokenRequest;
+        if (twoFactorToken != null && twoFactorProvider != null) {
+            request = new TokenRequest(email, hashedPassword, twoFactorProvider, twoFactorToken, remember,
+                deviceRequest);
+        } else if (storedTwoFactorToken != null) {
+            request = new TokenRequest(email, hashedPassword, TwoFactorProviderType.Remember,
+                storedTwoFactorToken, false, deviceRequest);
+        } else {
+            request = new TokenRequest(email, hashedPassword, null, null, false, deviceRequest);
+        }
+
+        const response = await this._apiService.postIdentityToken(request);
+
+        this._clearState();
+        const result = new AuthResult();
+        result.twoFactor = !(response as any).accessToken;
+
+        if (result.twoFactor) {
+            // two factor required
+            const twoFactorResponse = response as IdentityTwoFactorResponse;
+            this.email = email;
+            this.masterPasswordHash = hashedPassword;
+            this._key = this._setCryptoKeys ? key : null;
+            this.twoFactorProvidersData = twoFactorResponse.twoFactorProviders2;
+            result.twoFactorProviders = twoFactorResponse.twoFactorProviders2;
+            return result;
+        }
+
+        const tokenResponse = response as IdentityTokenResponse;
+
+        this.clientId = tokenResponse.clientId;
+        this.registrationAccessToken = tokenResponse.registrationAccessToken;
+
+        if (tokenResponse.twoFactorToken != null) {
+            await this._tokenService.setTwoFactorToken(tokenResponse.twoFactorToken, email);
+        }
+
+        await this._tokenService.setTokens(tokenResponse.accessToken, tokenResponse.refreshToken);
+        await this._userService.setInformation(this._tokenService.getUserId(), this._tokenService.getEmail(),
+            this._kdf, this._kdfIterations);
+        if (this._setCryptoKeys) {
+            await this._cryptoService.setKey(key);
+            await this._cryptoService.setKeyHash(hashedPassword);
+            await this._cryptoService.setEncKey(tokenResponse.key);
+
+            // User doesn't have a key pair yet (old account), let's generate one for them
+            if (tokenResponse.privateKey == null) {
+                try {
+                    const keyPair = await this._cryptoService.makeKeyPair();
+                    await this._apiService.postAccountKeys(new KeysRequest(keyPair[0], keyPair[1].encryptedString));
+                    tokenResponse.privateKey = keyPair[1].encryptedString;
+                } catch (e) {
+                    // tslint:disable-next-line
+                    console.error(e);
+                }
+            }
+
+            await this._cryptoService.setEncPrivateKey(tokenResponse.privateKey);
+        }
+
+        this._messagingService.send('loggedIn');
+        return result;
+    }
+
+    private _clearState(): void {
+        this.email = null;
+        this.masterPasswordHash = null;
+        this.twoFactorProvidersData = null;
+        this.selectedTwoFactorProviderType = null;
+    }
+}


### PR DESCRIPTION
To achieve this, I had to instantiate the AuthService in the main background and share it in the ServicesModules. Otherwise it was impossible to access the AuthService from the main background.

I also had to extend the original `IdentityTokenResponse` to add the `clientId` and `registrationToken` that are now returned by the stack on login (see https://github.com/cozy/cozy-stack/pull/2347). These infos are required to be able to call the [`DELETE /auth/register/:client-id` route](https://docs.cozy.io/en/cozy-stack/auth/#delete-authregisterclient-id).