### PR TITLE
fix(notification): Prevent buttons wrap

### DIFF
--- a/src/content/notification.css
+++ b/src/content/notification.css
@@ -1,6 +1,6 @@
 #notification-bar-iframe {
     width: 100%;
-    max-width: 420px;
+    max-width: 430px;
     box-shadow: 0 1px 3px 0 rgba(50, 54, 63, 0.19), 0 6px 18px 0 rgba(50, 54, 63, 0.19);
     border: solid 1px rgba(50, 54, 63, 0.12);
     position: fixed;

--- a/src/notification/bar.scss
+++ b/src/notification/bar.scss
@@ -103,6 +103,7 @@ button {
     top: 15px;
     float: right;
     border-radius: $border-radius-large;
+    display: flex;
 }
 
 .add-or-change {


### PR DESCRIPTION
A font rendering difference between chrome and firefox makes the buttons wider on firefox than on chrome in the notification bar:

|chrome|firefox|
|------|-------|
|![image](https://user-images.githubusercontent.com/1606068/73532552-34df2100-441d-11ea-8f33-98318bba8c4a.png)|![image](https://user-images.githubusercontent.com/1606068/73532531-285ac880-441d-11ea-9bef-cb7963929dd8.png)|


To fix this, I did two things:

* A wider notification bar, so in firefox the buttons render nicely
* Use display flex, so the buttons shrink by default but don't wrap if  there's not enough space

Now the rendering on firefox is ok:

![image](https://user-images.githubusercontent.com/1606068/73532641-6821b000-441d-11ea-8f3f-dc664fdaf9d2.png)