### PR TITLE
feat: Tell that konnectors accounts will be deleted on cipher delete

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -275,6 +275,9 @@
   "deleteItem": {
     "message": "Delete Item"
   },
+  "deleteSharedItem": {
+    "message": "Delete this identifier and data import"
+  },
   "viewItem": {
     "message": "View Item"
   },
@@ -508,6 +511,9 @@
   },
   "deleteItemConfirmation": {
     "message": "Are you sure you want to delete this item?"
+  },
+  "deleteSharedItemConfirmation": {
+    "message": "This identifier is currently used to import the account data into your Cozy. By deleting it, this automatic import will be interrupted. Are you sure ?"
   },
   "deletedItem": {
     "message": "Deleted item"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -272,6 +272,9 @@
   "deleteItem": {
     "message": "Supprimer l'élément"
   },
+  "deleteSharedItem": {
+    "message": "Supprimer cet identifiant et l'import des données"
+  },
   "viewItem": {
     "message": "Voir l'élément"
   },
@@ -502,6 +505,9 @@
   },
   "deleteItemConfirmation": {
     "message": "Êtes-vous sûr(e) de vouloir supprimer cet identifiant ?"
+  },
+  "deleteSharedItemConfirmation": {
+    "message": "Cet identifiant permet actuellement d'importer les données du compte dans votre Cozy. En le supprimant, cet import automatique sera interrompu.  Etes-vous sûr ?"
   },
   "deletedItem": {
     "message": "Identifiant supprimé"


### PR DESCRIPTION
When a user deletes a cipher, he is prompted to confirm. When the cipher
is linked to the cozy organization, we show a message telling him that the
konnectors accounts that use the cipher being deleted will be removed,
thus stopping automatic import of his data.