### PR TITLE
fix: Change icon color on login

### DIFF
--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -72,6 +72,10 @@ export const konnectorsService = new KonnectorsService(getBgService<CipherServic
     getBgService<StorageService>('storageService')(), getBgService<SettingsService>('settingsService')(),
     cozyClientService);
 export const authService = getBgService<AuthService>('authService')();
+
+// See https://github.com/cozy/cozy-keys-browser/pull/70 to have more context
+// about why we do this
+authService.setMessagingService(messagingService);
 export const searchService = new PopupSearchService(getBgService<SearchService>('searchService')(),
     getBgService<CipherService>('cipherService')(), getBgService<PlatformUtilsService>('platformUtilsService')());
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -87,6 +87,10 @@ export class AuthService extends BaseAuthService {
         );
     }
 
+    setMessagingService(messagingService: MessagingService) {
+        this._messagingService = messagingService;
+    }
+
     async logIn(email: string, masterPassword: string): Promise<AuthResult> {
         this.selectedTwoFactorProviderType = null;
         const key = await this._makePreloginKey(masterPassword, email);


### PR DESCRIPTION
After https://github.com/cozy/cozy-keys-browser/pull/64, the icon color was not changing when the user loggedin (it should go from grey indicating that the extension is not loggedin, to blue indicating that the extension is loggedin).

The problem is caused by the `loggedIn` message not being received by the `RuntimeBackground`. This message is sent by the `AuthService` through the `MessagingService`. At first I tried to get the `MessagingService` created in `MainBackground` (and that is used by the `AuthService`, as this one is also created by the `MainBackground`) instead of creating a new one. But it didn't work and I couldn't find why: the same `MessagingService` instance is used everywhere, but it doesn't catch the `loggedIn` messages.

So the solution I found is to keep the creation of a new `MessaginService` in the `ServicesModule`, and pass it to the `AuthService`.