### PR TITLE
Fix apps suggestion

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -176,7 +176,8 @@ export default class MainBackground {
             });
         this.syncService = new SyncService(this.userService, this.apiService, this.settingsService,
             this.folderService, this.cipherService, this.cryptoService, this.collectionService,
-        this.storageService, this.messagingService, async (expired: boolean) => await this.logout(expired), () => this.cozyClientService);
+            this.storageService, this.messagingService,
+            async (expired: boolean) => await this.logout(expired), () => this.cozyClientService);
         this.eventService = new EventService(this.storageService, this.apiService, this.userService,
             this.cipherService);
         this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.storageService);

--- a/src/popup/services/konnectors.service.ts
+++ b/src/popup/services/konnectors.service.ts
@@ -49,13 +49,11 @@ export class KonnectorsService {
     }
 
     async getInstalledKonnectors(client: any) {
-        const konnectors = await client.queryAll(client.find('io.cozy.konnectors'));
-        return konnectors.data;
+        return client.queryAll(client.find('io.cozy.konnectors'));
     }
 
     async getSuggestedKonnectors(client: any) {
-        const suggestions = await client.queryAll(client.find('io.cozy.apps.suggestions'));
-        return suggestions.data;
+        return client.queryAll(client.find('io.cozy.apps.suggestions'));
     }
 
     async sendKonnectorsSuggestion(client: any, konnectors: any[]) {

--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -128,10 +128,10 @@ export class AddEditComponent extends BaseAddEditComponent {
     async delete(): Promise<boolean> {
         const organizations = await this.userService.getAllOrganizations();
         const [cozyOrganization] = organizations.filter(
-            org => org.name === 'Cozy'
+            (org) => org.name === 'Cozy',
         );
         const isCozyOrganization =
-            this.cipher.organizationId === cozyOrganization.id
+            this.cipher.organizationId === cozyOrganization.id;
 
         const confirmationMessage = isCozyOrganization
             ? this.i18nService.t('deleteSharedItemConfirmation')
@@ -146,7 +146,7 @@ export class AddEditComponent extends BaseAddEditComponent {
             confirmationTitle,
             this.i18nService.t('yes'),
             this.i18nService.t('no'),
-            'warning'
+            'warning',
         );
 
         if (!confirmed) {


### PR DESCRIPTION
The apps suggestion was broken since this [commit](https://github.com/cozy/cozy-keys-browser/commit/d1e4d632ed802cd347b11cfb1a74c8826d20faaa), as `queryAll` does not return the `data` object, unlike `query`