### PR TITLE
feat: Send extension status through appInfo content script

### DIFF
--- a/docs/extension-status.md
+++ b/docs/extension-status.md
@@ -1,0 +1,32 @@
+# Extension status
+
+The extension is able to expose its current status to an app that needs to know
+it in order to do something. The only example of this today is
+[cozy-passwords](https://github.com/cozy/cozy-passwords) that needs the
+extension status to redirect the user to the right route to give him the best
+instructions.
+
+This status is exposed at the application's will: it's the role of the
+application to ask to the extension what's its status.
+
+To achieve this, the extension injects a script in each tab (this script is
+called a content script, and is located in `src/content/appInfo.ts`). This
+script adds an event listener on the `document` for the event
+`check-cozy-extension-status`. Here, it's important to have in mind that the
+`document` is the same for the script and the app. When an event is received,
+the script will send a message to the extension's main background
+(`src/backgound/main.background.ts`), which will check if the extension is
+currently authenticated or not and responds to the message with `installed` if
+it's not authenticated, or `connected` if it's authenticated. The script will
+then get the response and trigger an event on the `document` :
+
+* `cozy-extension-connected`: when the extension is connected
+* `cozy-extension-installed`: when the extension is not connected
+
+The app is then able to listen to these events and do what it wants when it
+receives one of them.
+
+So the content script acts like a "bridge" between the app and the extension,
+as it shares a bit of context with each one.
+
+The idea has been taken from https://krasimirtsonev.com/blog/article/Send-message-from-web-page-to-chrome-extensions-background-script.

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -262,6 +262,27 @@ export default class MainBackground {
             await this.windowsBackground.init();
         }
 
+        const checkCurrentStatus = async (msg: any) => {
+            const isAuthenticated = await this.userService.isAuthenticated();
+            const status = isAuthenticated ? 'connected' : 'installed';
+
+            return status;
+        };
+
+        BrowserApi.messageListener(
+            'main.background',
+            (msg: any, sender: any, sendResponse: any) => {
+                if (msg.command === 'checkextensionstatus') {
+                    checkCurrentStatus(msg).then(sendResponse);
+
+                    // The callback should return true if it's sending the
+                    // response asynchronously.
+                    // See https://developer.chrome.com/apps/runtime#event-onMessage
+                    return true;
+                }
+            },
+        );
+
         return new Promise((resolve) => {
             setTimeout(async () => {
                 await this.environmentService.setUrlsFromStorage();

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -58,8 +58,8 @@ export default class RuntimeBackground {
         }
 
         await this.checkOnInstalled();
-        BrowserApi.messageListener('runtime.background', async (msg: any, sender: any, sendResponse: any) => {
-            await this.processMessage(msg, sender, sendResponse);
+        BrowserApi.messageListener('runtime.background', (msg: any, sender: any, sendResponse: any) => {
+            this.processMessage(msg, sender, sendResponse);
         });
     }
 

--- a/src/browser/browserApi.ts
+++ b/src/browser/browserApi.ts
@@ -150,7 +150,7 @@ export class BrowserApi {
     static messageListener(name: string, callback: (message: any, sender: any, response: any) => void) {
         if (BrowserApi.isChromeApi) {
             chrome.runtime.onMessage.addListener((msg: any, sender: any, response: any) => {
-                callback(msg, sender, response);
+                return callback(msg, sender, response);
             });
         } else if (BrowserApi.isSafariApi) {
             SafariApp.addMessageListener(name, (message: any, sender: any, response: any) => {

--- a/src/content/appInfo.ts
+++ b/src/content/appInfo.ts
@@ -1,14 +1,20 @@
 import { BrowserApi } from '../browser/browserApi';
 
-window.addEventListener('message', async (event) => {
-    if (event.data && event.data.message && event.data.message.source === 'cozy-passwords') {
-        const version = BrowserApi.getApplicationVersion();
-        const message = {
-            source: 'cozy-extension',
-            version: version,
-        };
-        window.postMessage({
-            message: message,
-        }, event.origin);
-    }
+// This content script acts as a bridge between the app and the main.background
+// that is capable of telling if the extension is connected or not.
+// See https://krasimirtsonev.com/blog/article/Send-message-from-web-page-to-chrome-extensions-background-script
+//
+document.addEventListener('cozy.passwordextension.check-status', () => {
+    // This will not work in Safari. It's OK for now as we don't have a Safari
+    // extension, but we should find a way to send messages in Safari.
+    chrome.runtime.sendMessage(
+        { command: 'checkextensionstatus' },
+        (response: any) => {
+            const eventType = 'cozy.passwordextension.' + response;
+            const event = document.createEvent('Event');
+
+            event.initEvent(eventType);
+            document.dispatchEvent(event);
+        },
+    );
 });


### PR DESCRIPTION
The goal is to be able to tell whether the extension is connected or not. To achieve this, we need the `appInfo` content script to check if the user is currently authenticated or not. But it doesn't have access to the services. So we use `appInfo` as a bridge, as described in https://krasimirtsonev.com/blog/article/Send-message-from-web-page-to-chrome-extensions-background-script.

The app triggers a `checkextensionstatus` on `document`, which is caught by `appInfo`. Then `appInfo` sends a message to the extension. The `MainBackground` catches this message and responds to it. `appInfo` then triggers a `extensioninstalled` or `extensionconnected` event according to the status returned by `MainBackground`. The app can then catch these events and use it to behave like it wants (in our case, cozy-passwords switches views).