### PR TITLE
fix: Close App when we close the window

### DIFF
--- a/src/safari/desktop/AppDelegate.swift
+++ b/src/safari/desktop/AppDelegate.swift
@@ -9,4 +9,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_: Notification) {
         // Insert code here to tear down your application
     }
+    
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return true
+    }
 }


### PR DESCRIPTION
Since it's an Apple's requirement to pass the review : 
"The user interface of your app is not consistent with the macOS Human Interface Guidelines.
Specifically, we found that when the user closes the main application window there is no menu item to re-open it.
Alternatively, if the application is a single-window app, it might be appropriate to save data and quit the app when the main window is closed."

As our desktop app is a single window app, let's close the app when we close the window. It's just a boolean :) 