### PR TITLE
fix: Default placeholder hostname

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -323,7 +323,7 @@
       },
       "hostname": {
         "content": "$2",
-        "example": "bitwarden.com"
+        "example": "mycozy.cloud"
       }
     }
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -320,7 +320,7 @@
       },
       "hostname": {
         "content": "$2",
-        "example": "bitwarden.com"
+        "example": "mycozy.cloud"
       }
     }
   },


### PR DESCRIPTION
I don't know how [webVaultHostname](https://github.com/bitwarden/jslib/blob/b3d1e9d233aa7ed235d6ec0b26cdba41afa065ae/src/angular/components/lock.component.ts#L49) can be empty in some case, but here is an exemple of what I get sometimes 

<img width="364" alt="Capture d’écran 2020-04-10 à 09 03 14" src="https://user-images.githubusercontent.com/1107936/78971049-fa73bd80-7b0a-11ea-82eb-2e95cfed42dc.png">
