### PR TITLE
fix: Do not show empty sections

### DIFF
--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -27,35 +27,35 @@
         </ng-container>
     </div>
     <ng-container *ngIf="ciphers && ciphers.length && !showSearching()">
-        <div class="box list">
+        <div *ngIf="ciphersByType[cipherType.Card].length > 0" class="box list">
             <div class="box-header">
                 {{'cards' | i18n}}
                 <span class="flex-right">{{countByType(cipherType.Card)}}</span>
             </div>
             <div class="box-content">
-                <app-ciphers-list [ciphers]="ciphersByType(cipherType.Card)" title="{{'viewItem' | i18n}}"
+                <app-ciphers-list [ciphers]="ciphersByType[cipherType.Card]" title="{{'viewItem' | i18n}}"
                     (onSelected)="selectCipher($event)" (onDoubleSelected)="launchCipher($event)">
                 </app-ciphers-list>
             </div>
         </div>
-        <div class="box list">
+        <div *ngIf="ciphersByType[cipherType.Card].Identity > 0" class="box list">
             <div class="box-header">
                 {{'identities' | i18n}}
                 <span class="flex-right">{{countByType(cipherType.Identity)}}</span>
             </div>
             <div class="box-content">
-                <app-ciphers-list [ciphers]="ciphersByType(cipherType.Identity)" title="{{'viewItem' | i18n}}"
+                <app-ciphers-list [ciphers]="ciphersByType[cipherType.Identity]" title="{{'viewItem' | i18n}}"
                     (onSelected)="selectCipher($event)" (onDoubleSelected)="launchCipher($event)">
                 </app-ciphers-list>
             </div>
         </div>
-        <div class="box list">
+        <div *ngIf="ciphersByType[cipherType.Login].length > 0" class="box list">
             <div class="box-header">
                 {{'logins' | i18n}}
                 <div class="flex-right">{{countByType(cipherType.Login)}}</div>
             </div>
             <div class="box-content">
-                <app-ciphers-list [ciphers]="ciphersByType(cipherType.Login)" title="{{'viewItem' | i18n}}"
+                <app-ciphers-list [ciphers]="ciphersByType[cipherType.Login]" title="{{'viewItem' | i18n}}"
                     (onSelected)="selectCipher($event)" (onDoubleSelected)="launchCipher($event)"></app-ciphers-list>
             </div>
         </div>

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -66,6 +66,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
     private hasSearched = false;
     private hasLoadedAllCiphers = false;
     private allCiphers: CipherView[] = null;
+    private ciphersByType: any;
 
     constructor(collectionService: CollectionService, folderService: FolderService,
         storageService: StorageService, userService: UserService,
@@ -158,6 +159,10 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
                 typeCounts.set(c.type, 1);
             }
         });
+        this.ciphersByType = {}
+        this.ciphersByType[CipherType.Card] = this._ciphersByType(CipherType.Card)
+        this.ciphersByType[CipherType.Identity] = this._ciphersByType(CipherType.Identity)
+        this.ciphersByType[CipherType.Login] = this._ciphersByType(CipherType.Login)
         this.typeCounts = typeCounts;
     }
 
@@ -183,7 +188,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         }, timeout);
     }
 
-    ciphersByType(type: CipherType) {
+    _ciphersByType(type: CipherType) {
         return this.ciphers.filter((c) => c.type === type);
     }
 


### PR DESCRIPTION
Sections without ciphers in the Vault page were shown even if
no ciphers from the corresponding type were present.