### PR TITLE
fix: Remove not needed entitlements

### DIFF
--- a/src/safari/safari/safari.entitlements
+++ b/src/safari/safari/safari.entitlements
@@ -8,7 +8,5 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
You got a rejection from apple saying that we don't have a functionnality that use this permission. 

Tried without, and it seems to works well :
- added an account Cozy Pass Mobile and it appears on my extension panel 
- logged to a website and had the popup to save my credentials 