### PR TITLE
Fixes on grouping view

### DIFF
--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -26,7 +26,7 @@
             <button (click)="addCipher()" class="btn block primary link">{{'addItem' | i18n}}</button>
         </ng-container>
     </div>
-    <ng-container *ngIf="ciphers && ciphers.length && !showSearching()">
+    <ng-container *ngIf="(ciphers && ciphers.length && !showSearching()) || deletedCount">
         <div *ngIf="ciphersByType[cipherType.Card].length > 0" class="box list">
             <div class="box-header">
                 {{'cards' | i18n}}

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -160,6 +160,9 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         await this.search(null);
         const typeCounts = new Map<CipherType, number>();
         this.ciphers.forEach((c) => {
+            if (c.isDeleted) {
+                return;
+            }
             if (typeCounts.has(c.type)) {
                 typeCounts.set(c.type, typeCounts.get(c.type) + 1);
             } else {

--- a/src/popup/vault/groupings.component.ts
+++ b/src/popup/vault/groupings.component.ts
@@ -82,6 +82,11 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
     }
 
     async ngOnInit() {
+        this.ciphersByType = {};
+        this.ciphersByType[CipherType.Card] = [];
+        this.ciphersByType[CipherType.Identity] = [];
+        this.ciphersByType[CipherType.Login] = [];
+
         this.searchTypeSearch = !this.platformUtilsService.isSafari();
         this.showLeftHeader = !this.platformUtilsService.isSafari() &&
             !(this.popupUtils.inSidebar(window) && this.platformUtilsService.isFirefox());
@@ -165,6 +170,7 @@ export class GroupingsComponent extends BaseGroupingsComponent implements OnInit
         this.ciphersByType[CipherType.Card] = this._ciphersByType(CipherType.Card);
         this.ciphersByType[CipherType.Identity] = this._ciphersByType(CipherType.Identity);
         this.ciphersByType[CipherType.Login] = this._ciphersByType(CipherType.Login);
+
         this.typeCounts = typeCounts;
     }
 


### PR DESCRIPTION
This PR fixes 2 things:
- Avoid errors when listing ciphers by initializing the expected  structures
- Display the trash even when no ciphers are available.

:warning: This should be merged after https://github.com/cozy/cozy-keys-browser/pull/90