### PR TITLE
refactor: Override jslib delete

### DIFF
--- a/src/popup/vault/add-edit.component.ts
+++ b/src/popup/vault/add-edit.component.ts
@@ -145,8 +145,11 @@ export class AddEditComponent extends BaseAddEditComponent {
         return confirmed;
     }
 
+    /**
+     * @override by Cozy
+     * Calls the overrided deleteCipher
+     */
     async delete(): Promise<boolean> {
-        // Calls an override by Cozy
         const deleted = await deleteCipher(this.cipherService, this.userService, this.i18nService,
             this.platformUtilsService, this.cipher);
         if (deleted) {

--- a/src/popup/vault/utils.ts
+++ b/src/popup/vault/utils.ts
@@ -1,0 +1,59 @@
+import {
+  EventEmitter,
+} from '@angular/core';
+
+import { CipherService } from 'jslib/abstractions/cipher.service';
+import { I18nService } from 'jslib/abstractions/i18n.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { UserService } from 'jslib/abstractions/user.service';
+import { CipherView } from 'jslib/models/view/cipherView';
+
+/**
+ * @override by Cozy
+ * This method is extracted from the jslib:
+ * https://github.com/bitwarden/jslib/blob/
+ * f30d6f8027055507abfdefd1eeb5d9aab25cc601/src/angular/components/view.component.ts#L117
+ * We need to display a specific message for ciphers shared with Cozy.
+ * This method is called by AddEditComponent and ViewComponent.
+ */
+export const deleteCipher = async (cipherService: CipherService, userService: UserService,
+  i18nService: I18nService, platformUtilsService: PlatformUtilsService, cipher: CipherView): Promise<boolean>  => {
+  const organizations = await userService.getAllOrganizations();
+  const [cozyOrganization] = organizations.filter(
+      (org) => org.name === 'Cozy',
+  );
+  const isCozyOrganization =
+      cipher.organizationId === cozyOrganization.id;
+
+  const confirmationMessage = isCozyOrganization
+      ? i18nService.t('deleteSharedItemConfirmation')
+      : i18nService.t('deleteItemConfirmation');
+
+  const confirmationTitle = isCozyOrganization
+      ? i18nService.t('deleteSharedItem')
+      : i18nService.t('deleteItem');
+
+  const confirmed = await platformUtilsService.showDialog(
+      confirmationMessage,
+      confirmationTitle,
+      i18nService.t('yes'),
+      i18nService.t('no'),
+      'warning',
+  );
+
+  if (!confirmed) {
+      return false;
+  }
+
+  try {
+    const deletePromise = cipher.isDeleted ? cipherService.deleteWithServer(cipher.id)
+            : cipherService.softDeleteWithServer(cipher.id);
+    await deletePromise;
+    platformUtilsService.eventTrack('Deleted Cipher');
+    platformUtilsService.showToast('success', null, i18nService.t('deletedItem'));
+    const onDeletedCipher = new EventEmitter<CipherView>();
+    onDeletedCipher.emit(cipher);
+  } catch { }
+
+  return true;
+};

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -93,8 +93,11 @@ export class ViewComponent extends BaseViewComponent {
         return false;
     }
 
+    /**
+     * @override by Cozy
+     * Calls the overrided deleteCipher
+     */
     async delete(): Promise<boolean> {
-        // Calls an override by Cozy
         const deleted = await deleteCipher(this.cipherService, this.userService, this.i18nService,
             this.platformUtilsService, this.cipher);
         if (deleted) {

--- a/src/popup/vault/view.component.ts
+++ b/src/popup/vault/view.component.ts
@@ -23,6 +23,8 @@ import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 
 import { ViewComponent as BaseViewComponent } from 'jslib/angular/components/view.component';
 
+import { deleteCipher } from './utils';
+
 @Component({
     selector: 'app-vault-view',
     templateUrl: 'view.component.html',
@@ -91,8 +93,11 @@ export class ViewComponent extends BaseViewComponent {
         return false;
     }
 
-    async delete() {
-        if (await super.delete()) {
+    async delete(): Promise<boolean> {
+        // Calls an override by Cozy
+        const deleted = await deleteCipher(this.cipherService, this.userService, this.i18nService,
+            this.platformUtilsService, this.cipher);
+        if (deleted) {
             this.close();
             return true;
         }


### PR DESCRIPTION
Since these bitwarden's
[changes](https://github.com/cozy/cozy-keys-browser/commit/411630296536340c4db998b1dd96faacc619e59e#diff-21589230df2863fc1476560862b8f002), it is now possible to delete a cipher from the View component. However, we need
to override it from the jslib to display a specific message for ciphers shared with Cozy.
This also allows to call the same method from the 2 components using
the delete, ViewComponent and AddEditComponent.