### PR TITLE
Fix infinite loop

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -309,7 +309,7 @@ export default class MainBackground {
         this.runtimeBackground = new RuntimeBackground(this, this.autofillService, this.cipherService,
             this.platformUtilsService as BrowserPlatformUtilsService, this.storageService, this.i18nService,
             this.notificationsService, this.systemService, this.vaultTimeoutService,
-            this.environmentService,
+            this.environmentService, this.cozyClientService,
             this.konnectorsService, this.syncService, this.authService, this.cryptoService, this.userService);
 
     }

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -438,7 +438,6 @@ export default class MainBackground {
         ]);
 
         // Clear auth and token afterwards, as previous services might need it
-        await this.authService.clear();
         await this.tokenService.clearToken();
 
         this.searchService.clearIndex();

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -257,7 +257,7 @@ export default class MainBackground {
         this.syncService = new SyncService(this.userService, this.apiService, this.settingsService,
             this.folderService, this.cipherService, this.cryptoService, this.collectionService,
             this.storageService, this.messagingService, this.policyService,
-            async (expired: boolean) => await this.logout(expired), () => this.cozyClientService);
+            async (expired: boolean) => await this.logout(expired), this.cozyClientService);
         this.eventService = new EventService(this.storageService, this.apiService, this.userService,
             this.cipherService);
         this.passwordGenerationService = new PasswordGenerationService(this.cryptoService, this.storageService,

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -101,6 +101,7 @@ export default class RuntimeBackground {
                     });
                 }
                 // 2- logout
+                await this.authService.clear(); // moved from the logout to avoid potential infinite loop
                 await this.main.logout(msg.expired);
                 break;
             case 'syncCompleted':

--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -33,6 +33,7 @@ import { Utils } from 'jslib/misc/utils';
 import { PasswordVerificationRequest } from 'jslib/models/request/passwordVerificationRequest';
 import { KonnectorsService } from '../popup/services/konnectors.service';
 import { AuthService } from '../services/auth.service';
+import { CozyClientService } from 'src/popup/services/cozyClient.service';
 
 export default class RuntimeBackground {
     private runtime: any;
@@ -47,6 +48,7 @@ export default class RuntimeBackground {
         private notificationsService: NotificationsService,
         private systemService: SystemService, private vaultTimeoutService: VaultTimeoutService,
         private environmentService: EnvironmentService,
+        private cozyClientService: CozyClientService,
         private konnectorsService: KonnectorsService, private syncService: SyncService,
         private authService: AuthService, private cryptoService: CryptoService,
         private userService: UserService) {
@@ -838,6 +840,9 @@ export default class RuntimeBackground {
         await this.main.refreshBadgeAndMenu(false);
         this.notificationsService.updateConnection(command === 'unlocked');
         this.systemService.cancelProcessReload();
+
+        await this.cozyClientService.createClient();
+
         // ask notificationbar of all tabs to retry to collect pageDetails in order to activate in-page-menu
         let enableInPageMenu = await this.storageService.get<boolean>(
             LocalConstantsService.enableInPageMenuKey);

--- a/src/popup/services/cozyClient.service.ts
+++ b/src/popup/services/cozyClient.service.ts
@@ -35,42 +35,27 @@ export class CozyClientService {
     }
 
     async getClientInstance () {
-        try {
-            if (this.instance) {
-                const token = await this.apiService.getActiveBearerToken();
-                // If the instance's token differ from the active bearer, a refresh is needed.
-                if (token === this.instance.options.token) {
-                    return this.instance;
-                }
+        if (this.instance) {
+            const token = await this.apiService.getActiveBearerToken();
+            // If the instance's token differ from the active bearer, a refresh is needed.
+            if (token === this.instance.options.token) {
+                return this.instance;
             }
-            this.instance = await this.createClient();
-        } catch (err) {
-            /* tslint:disable-next-line */
-            console.error('Error while initializing cozy-client');
-            /* tslint:disable-next-line */
-            console.error(err);
         }
+        this.instance = await this.createClient();
         return this.instance;
     }
 
     async createClient() {
-        try  {
-            const uri = this.getCozyURL();
-            const token = await this.apiService.getActiveBearerToken();
-            this.instance = new CozyClient({ uri: uri, token: token });
-        } catch (err) {
-            /* tslint:disable-next-line */
-            console.error('Error while initializing cozy-client');
-            /* tslint:disable-next-line */
-            console.error(err);
-        }
-
+        const uri = this.getCozyURL();
+        const token = await this.apiService.getActiveBearerToken();
+        this.instance = new CozyClient({ uri: uri, token: token });
         return this.instance;
     }
 
     async updateSynchronizedAt() {
-        const client = await this.getClientInstance();
         try {
+            const client = await this.getClientInstance();
             await client.getStackClient().fetchJSON('POST', '/settings/synchronized');
         } catch (err) {
             /* tslint:disable-next-line */
@@ -84,9 +69,9 @@ export class CozyClientService {
         if (!clientId || !registrationAccessToken) {
             return
         }
-        const client = await this.getClientInstance();
 
         try {
+            const client = await this.getClientInstance();
             await client.getStackClient().fetch(
                 'DELETE',
                 '/auth/register/' + clientId,

--- a/src/popup/services/konnectors.service.ts
+++ b/src/popup/services/konnectors.service.ts
@@ -29,7 +29,7 @@ export class KonnectorsService {
         try {
             const isDisabled = await this.storageService.get<boolean>(ConstantsService.disableKonnectorsSuggestionsKey);
             if (!isDisabled) {
-                const cozyClient = await this.cozyClientService.createClient();
+                const cozyClient = await this.cozyClientService.getClientInstance();
                 const allKonnectors = await this.getRegistryKonnectors(cozyClient);
                 const installedKonnectors = await this.getInstalledKonnectors(cozyClient);
                 const suggestedKonnectors = await this.getSuggestedKonnectors(cozyClient);
@@ -39,7 +39,12 @@ export class KonnectorsService {
                 );
                 this.sendKonnectorsSuggestion(cozyClient, konnectorsToSuggest);
             }
-        } catch (e) { }
+        } catch (e) {
+            /* tslint:disable-next-line */
+            console.error(e);
+            /* tslint:disable-next-line */
+            console.error('Error while trying to make konnectors suggestions');
+        }
     }
 
     getRegistryKonnectors(client: any) {

--- a/src/popup/services/sync.service.ts
+++ b/src/popup/services/sync.service.ts
@@ -53,7 +53,7 @@ export class SyncService extends BaseSyncService {
         messagingService: MessagingService,
         policyService: PolicyService,
         logoutCallback: (expired: boolean) => Promise<void>,
-        private cozyClientService: () => CozyClientService,
+        private cozyClientService: CozyClientService,
     ) {
             super(
                 userService,
@@ -76,8 +76,10 @@ export class SyncService extends BaseSyncService {
     async setLastSync(date: Date): Promise<any> {
         await super.setLastSync(date);
 
-        const cozyClientService = this.cozyClientService();
-        await cozyClientService.updateSynchronizedAt();
+        // Update remote sync date only for non-zero date, which is used for logout
+        if (date.getTime() !== new Date(0).getTime()) {
+            await this.cozyClientService.updateSynchronizedAt();
+        }
     }
 
     /*

--- a/src/popup/services/sync.service.ts
+++ b/src/popup/services/sync.service.ts
@@ -77,7 +77,7 @@ export class SyncService extends BaseSyncService {
         await super.setLastSync(date);
 
         // Update remote sync date only for non-zero date, which is used for logout
-        if (date.getTime() !== new Date(0).getTime()) {
+        if (date.getTime() !== 0) {
             await this.cozyClientService.updateSynchronizedAt();
         }
     }


### PR DESCRIPTION
*    Fix potential infinite loops that might be caused when a communication with the stack failed during the logout (as the failure will it self call the logout callback)
*    Improve cozy-client handling: we force an automatic instance recreation when the cozy-client's token is no longer the same than the one saved by the jslib. This was causing errors when the token was refreshed by the jslib and cozy-client was using the old credentials.
