### PR TITLE
feat: improve url handling in login form (slug, dash and mispell)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -438,6 +438,9 @@
   "noEmailAsCozyUrl": {
     "message": "The Cozy URL is not your email"
   },
+  "hasMispelledCozy": {
+    "message": "Woops, the address is not correct. Try with \"cozy\" with a \"z\"!"
+  },
   "masterPassRequired": {
     "message": "Cozy password is required."
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -435,6 +435,9 @@
   "noEmailAsCozyUrl": {
     "message": "L'URL de votre Cozy n'est pas votre email"
   },
+  "hasMispelledCozy": {
+    "message": "Oups, ce n'est pas la bonne adresse. Essayez d'écrire \"cozy\" avec un \"z\" !"
+  },
   "masterPassRequired": {
     "message": "Le mot de passe du Cozy est requis."
   },

--- a/src/popup/accounts/login.component.spec.ts
+++ b/src/popup/accounts/login.component.spec.ts
@@ -1,7 +1,8 @@
+import { CozySanitizeUrlService } from '../services/cozySanitizeUrl.service';
 import { LoginComponent } from './login.component';
 
 describe('url input', () => {
-    const loginComponent = new LoginComponent(null, null, null, null, null, null, null, null);
+    const loginComponent = new LoginComponent(null, null, null, null, null, null, null, null, new CozySanitizeUrlService());
     it('should return undefined if the input is empty', () => {
         const inputUrl = '';
         expect(() => {
@@ -38,5 +39,31 @@ describe('url input', () => {
         const inputUrl = 'http://claude.cozy.tools:8080';
         const url = loginComponent.sanitizeUrlInput(inputUrl);
         expect(url).toEqual('http://claude.cozy.tools:8080');
+    });
+    it('should not try to remove slug if present and url has a custom domain', () => {
+        const inputUrl = 'claude-drive.on-premise.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://claude-drive.on-premise.cloud');
+    });
+    it('should return the correct url if domains contains a dash', () => {
+        const inputUrl = 'claude.on-premise.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://claude.on-premise.cloud');
+    });
+    it('should return the correct url if domains contains a dash and cozy is installed on domain root', () => {
+        const inputUrl = 'https://on-premise.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://on-premise.cloud');
+    });
+    it(`should throw if user write 'mycosy' instead of 'mycozy'`, () => {
+        const inputUrl = 'https://claude.mycosy.cloud';
+        expect(() => {
+            loginComponent.sanitizeUrlInput(inputUrl);
+        }).toThrow(new Error('hasMispelledCozy'));
+    });
+    it(`should accept real '*cosy*' url`, () => {
+        const inputUrl = 'https://claude.realdomaincosy.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://claude.realdomaincosy.cloud');
     });
 });

--- a/src/popup/accounts/login.component.ts
+++ b/src/popup/accounts/login.component.ts
@@ -16,6 +16,7 @@ import { AuthResult } from 'jslib/models/domain/authResult';
 import { ConstantsService } from 'jslib/services/constants.service';
 
 import BrowserMessagingService from '../../services/browserMessaging.service';
+import { CozySanitizeUrlService } from "../services/cozySanitizeUrl.service";
 
 const messagingService = new BrowserMessagingService();
 
@@ -63,7 +64,8 @@ export class LoginComponent implements OnInit {
     constructor(protected authService: AuthService, protected router: Router,
         protected platformUtilsService: PlatformUtilsService, protected i18nService: I18nService,
         protected syncService: SyncService, private storageService: StorageService,
-        protected stateService: StorageService, protected environmentService: EnvironmentService) {
+        protected stateService: StorageService, protected environmentService: EnvironmentService,
+        protected cozySanitizeUrlService: CozySanitizeUrlService) {
 
             this.authService = authService;
             this.router = router;
@@ -102,21 +104,12 @@ export class LoginComponent implements OnInit {
         if (inputUrl.includes('@')) {
             throw new Error('noEmailAsCozyUrl');
         }
-        // String sanitize
-        inputUrl = inputUrl.trim().toLowerCase();
-        inputUrl = inputUrl.replace(/\/+$/, ''); // remove trailing '/'
 
-        // Extract protocol
-        const regexpProtocol = /^(https?:\/\/)?(www\.)?/;
-        const protocolMatches = inputUrl.match(regexpProtocol);
-        const protocol = protocolMatches[1] ? protocolMatches[1] : 'https://';
-        inputUrl = inputUrl.replace(regexpProtocol, '');
-        // Handle url with app slug or with no domain
-        const regexpFQDN = /^([a-z0-9]+)(?:-[a-z0-9]+)?(?:\.(.*))?$/;
-        const matches = inputUrl.match(regexpFQDN);
-        const cozySlug = matches[1];
-        const domain = matches[2] ? matches[2] : 'mycozy.cloud';
-        return `${protocol}${cozySlug}.${domain}`;
+        if (this.cozySanitizeUrlService.hasMispelledCozy(inputUrl)){
+            throw new Error('hasMispelledCozy');
+        }
+
+        return this.cozySanitizeUrlService.normalizeURL(inputUrl, this.cozySanitizeUrlService.cozyDomain);
     }
 
     async submit() {
@@ -182,9 +175,17 @@ export class LoginComponent implements OnInit {
                 }
             }
         } catch (e) {
-            if (e.message === 'cozyUrlRequired' || e.message === 'noEmailAsCozyUrl') {
+            const translatableMessages = [
+                'cozyUrlRequired',
+                'noEmailAsCozyUrl',
+                'hasMispelledCozy'
+            ]
+            
+            if (translatableMessages.includes(e.message)) {
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
-                    this.i18nService.t(e.message));
+                this.i18nService.t(e.message));
+            } else {
+                this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), '');
             }
         }
     }

--- a/src/popup/services/cozySanitizeUrl.service.ts
+++ b/src/popup/services/cozySanitizeUrl.service.ts
@@ -1,0 +1,47 @@
+/*
+    This code is from https://github.com/cozy/cozy-libs/blob/ff41af377c94d8ab5e34ffe91984bb1b1efd3b36/packages/cozy-authentication/src/steps/SelectServer.jsx#L194
+*/
+export class CozySanitizeUrlService {
+    public cozyDomain = '.mycozy.cloud'
+
+    constructor() {}
+
+    protected isValideCozyName = (value: string): boolean => {
+        return (
+            /^[a-zA-Z0-9-]*$/.test(value) &&
+            value.length > 0 &&
+            value.length < 63
+        );
+    };
+    hasMispelledCozy = (value: string): boolean => /\.mycosy\./.test(value);
+    protected hasAtSign = (value: string): boolean => /.*@.*/.test(value);
+
+    protected appendDomain = (value: string, domain: string) =>
+        /\./.test(value) ? value : `${value}${domain}`;
+
+    protected prependProtocol = (value: string) =>
+        /^http(s)?:\/\//.test(value) ? value : `https://${value}`;
+
+    protected removeAppSlug = (value: string) => {
+        const matchedSlugs = /^https?:\/\/\w+(-\w+)\./gi.exec(value);
+
+        return matchedSlugs ? value.replace(matchedSlugs[1], '') : value;
+    };
+
+    normalizeURL = (value: string, defaultDomain: string): string => {
+        const valueWithProtocol = this.prependProtocol(value);
+        const valueWithProtocolAndDomain = this.appendDomain(
+            valueWithProtocol,
+            defaultDomain
+        );
+
+        const isDefaultDomain = new RegExp(`${defaultDomain}$`).test(
+            valueWithProtocolAndDomain
+        );
+
+        
+        return isDefaultDomain
+            ? this.removeAppSlug(valueWithProtocolAndDomain)
+            : valueWithProtocolAndDomain;
+    };
+}

--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -1,184 +1,187 @@
-import {
-    APP_INITIALIZER,
-    LOCALE_ID,
-    NgModule,
-} from '@angular/core';
-
-import { ToasterModule } from 'angular2-toaster';
-
-import { LaunchGuardService } from './launch-guard.service';
-
-import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
-import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
-import { ValidationService } from 'jslib/angular/services/validation.service';
-
-import { BrowserApi } from '../../browser/browserApi';
-
-import { CozyClientService } from './cozyClient.service';
-import { KonnectorsService } from './konnectors.service';
-
-import { ApiService } from 'jslib/abstractions/api.service';
-import { AppIdService } from 'jslib/abstractions/appId.service';
-import { AuditService } from 'jslib/abstractions/audit.service';
-import { AuthService as AuthServiceAbstraction } from 'jslib/abstractions/auth.service';
-import { CipherService } from 'jslib/abstractions/cipher.service';
-import { CollectionService } from 'jslib/abstractions/collection.service';
-import { CryptoFunctionService } from 'jslib/abstractions/cryptoFunction.service';
-import { CryptoService } from 'jslib/abstractions/crypto.service';
-import { EnvironmentService } from 'jslib/abstractions/environment.service';
-import { EventService } from 'jslib/abstractions/event.service';
-import { ExportService } from 'jslib/abstractions/export.service';
-import { FolderService } from 'jslib/abstractions/folder.service';
-import { I18nService } from 'jslib/abstractions/i18n.service';
-import { MessagingService } from 'jslib/abstractions/messaging.service';
-import { NotificationsService } from 'jslib/abstractions/notifications.service';
-import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
-import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
-import { PolicyService } from 'jslib/abstractions/policy.service';
-import { SearchService as SearchServiceAbstraction } from 'jslib/abstractions/search.service';
-import { SettingsService } from 'jslib/abstractions/settings.service';
-import { StateService as StateServiceAbstraction } from 'jslib/abstractions/state.service';
-import { StorageService } from 'jslib/abstractions/storage.service';
-import { SyncService } from 'jslib/abstractions/sync.service';
-import { TokenService } from 'jslib/abstractions/token.service';
-import { TotpService } from 'jslib/abstractions/totp.service';
-import { UserService } from 'jslib/abstractions/user.service';
-import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
-
-import { AutofillService } from '../../services/abstractions/autofill.service';
-import BrowserMessagingService from '../../services/browserMessaging.service';
-
-import { ConstantsService } from 'jslib/services/constants.service';
-import { SearchService } from 'jslib/services/search.service';
-import { StateService } from 'jslib/services/state.service';
-
-import { PopupSearchService } from './popup-search.service';
-import { PopupUtilsService } from './popup-utils.service';
-
-import { AuthService } from '../../services/auth.service';
-
-function getBgService<T>(service: string) {
-    return (): T => {
-        const page = BrowserApi.getBackgroundPage();
-        return page ? page.bitwardenMain[service] as T : null;
-    };
-}
-
-export const stateService = new StateService();
-export const messagingService = new BrowserMessagingService();
-export const cozyClientService = new CozyClientService(getBgService<EnvironmentService>('environmentService')(),
-    getBgService<ApiService>('apiService')());
-export const konnectorsService = new KonnectorsService(getBgService<CipherService>('cipherService')(),
-    getBgService<StorageService>('storageService')(), getBgService<SettingsService>('settingsService')(),
-    cozyClientService);
-export const authService = getBgService<AuthService>('authService')();
-
-// See https://github.com/cozy/cozy-keys-browser/pull/70 to have more context
-// about why we do this
-authService.setMessagingService(messagingService);
-export const searchService = new PopupSearchService(getBgService<SearchService>('searchService')(),
-    getBgService<CipherService>('cipherService')());
-
-export function initFactory(i18nService: I18nService, storageService: StorageService,
-    popupUtilsService: PopupUtilsService): Function {
-    return async () => {
-        if (!popupUtilsService.inPopup(window)) {
-            window.document.body.classList.add('body-full');
-        } else if (window.screen.availHeight < 600) {
-            window.document.body.classList.add('body-xs');
-        } else if (window.screen.availHeight <= 800) {
-            window.document.body.classList.add('body-sm');
-        }
-
-        if (BrowserApi.getBackgroundPage() != null) {
-            stateService.save(ConstantsService.disableFaviconKey,
-                await storageService.get<boolean>(ConstantsService.disableFaviconKey));
-
-            let theme = await storageService.get<string>(ConstantsService.themeKey);
-            if (theme == null) {
-                theme = 'light';
-            }
-            window.document.documentElement.classList.add('locale_' + i18nService.translationLocale);
-            window.document.documentElement.classList.add('theme_' + theme);
-
-            authService.init();
-        }
-    };
-}
-
-@NgModule({
-    imports: [
-        ToasterModule,
-    ],
-    declarations: [],
-    providers: [
-        ValidationService,
-        AuthGuardService,
-        LaunchGuardService,
-        PopupUtilsService,
-        BroadcasterService,
-        { provide: CozyClientService, useValue: cozyClientService },
-        { provide: KonnectorsService, useValue: konnectorsService },
-        { provide: MessagingService, useValue: messagingService },
-        { provide: AuthServiceAbstraction, useValue: authService },
-        { provide: StateServiceAbstraction, useValue: stateService },
-        { provide: SearchServiceAbstraction, useValue: searchService },
-        { provide: AuditService, useFactory: getBgService<AuditService>('auditService'), deps: [] },
-        { provide: CipherService, useFactory: getBgService<CipherService>('cipherService'), deps: [] },
-        {
-            provide: CryptoFunctionService,
-            useFactory: getBgService<CryptoFunctionService>('cryptoFunctionService'),
-            deps: [],
-        },
-        { provide: FolderService, useFactory: getBgService<FolderService>('folderService'), deps: [] },
-        { provide: CollectionService, useFactory: getBgService<CollectionService>('collectionService'), deps: [] },
-        { provide: EnvironmentService, useFactory: getBgService<EnvironmentService>('environmentService'), deps: [] },
-        { provide: TotpService, useFactory: getBgService<TotpService>('totpService'), deps: [] },
-        { provide: TokenService, useFactory: getBgService<TokenService>('tokenService'), deps: [] },
-        { provide: I18nService, useFactory: getBgService<I18nService>('i18nService'), deps: [] },
-        { provide: CryptoService, useFactory: getBgService<CryptoService>('cryptoService'), deps: [] },
-        { provide: EventService, useFactory: getBgService<EventService>('eventService'), deps: [] },
-        { provide: PolicyService, useFactory: getBgService<PolicyService>('policyService'), deps: [] },
-        {
-            provide: PlatformUtilsService,
-            useFactory: getBgService<PlatformUtilsService>('platformUtilsService'),
-            deps: [],
-        },
-        {
-            provide: PasswordGenerationService,
-            useFactory: getBgService<PasswordGenerationService>('passwordGenerationService'),
-            deps: [],
-        },
-        { provide: ApiService, useFactory: getBgService<ApiService>('apiService'), deps: [] },
-        { provide: SyncService, useFactory: getBgService<SyncService>('syncService'), deps: [] },
-        { provide: UserService, useFactory: getBgService<UserService>('userService'), deps: [] },
-        { provide: SettingsService, useFactory: getBgService<SettingsService>('settingsService'), deps: [] },
-        { provide: StorageService, useFactory: getBgService<StorageService>('storageService'), deps: [] },
-        { provide: AppIdService, useFactory: getBgService<AppIdService>('appIdService'), deps: [] },
-        { provide: AutofillService, useFactory: getBgService<AutofillService>('autofillService'), deps: [] },
-        { provide: ExportService, useFactory: getBgService<ExportService>('exportService'), deps: [] },
-        {
-            provide: VaultTimeoutService,
-            useFactory: getBgService<VaultTimeoutService>('vaultTimeoutService'),
-            deps: [],
-        },
-        {
-            provide: NotificationsService,
-            useFactory: getBgService<NotificationsService>('notificationsService'),
-            deps: [],
-        },
-        {
-            provide: APP_INITIALIZER,
-            useFactory: initFactory,
-            deps: [I18nService, StorageService, PopupUtilsService],
-            multi: true,
-        },
-        {
-            provide: LOCALE_ID,
-            useFactory: () => getBgService<I18nService>('i18nService')().translationLocale,
-            deps: [],
-        },
-    ],
-})
-export class ServicesModule {
-}
+import { 
+    APP_INITIALIZER, 
+    LOCALE_ID, 
+    NgModule, 
+} from '@angular/core'; 
+ 
+import { ToasterModule } from 'angular2-toaster'; 
+ 
+import { LaunchGuardService } from './launch-guard.service'; 
+ 
+import { AuthGuardService } from 'jslib/angular/services/auth-guard.service'; 
+import { BroadcasterService } from 'jslib/angular/services/broadcaster.service'; 
+import { ValidationService } from 'jslib/angular/services/validation.service'; 
+ 
+import { BrowserApi } from '../../browser/browserApi'; 
+ 
+import { CozyClientService } from './cozyClient.service'; 
+import { CozySanitizeUrlService } from './cozySanitizeUrl.service';
+import { KonnectorsService } from './konnectors.service'; 
+ 
+import { ApiService } from 'jslib/abstractions/api.service'; 
+import { AppIdService } from 'jslib/abstractions/appId.service'; 
+import { AuditService } from 'jslib/abstractions/audit.service'; 
+import { AuthService as AuthServiceAbstraction } from 'jslib/abstractions/auth.service'; 
+import { CipherService } from 'jslib/abstractions/cipher.service'; 
+import { CollectionService } from 'jslib/abstractions/collection.service'; 
+import { CryptoFunctionService } from 'jslib/abstractions/cryptoFunction.service'; 
+import { CryptoService } from 'jslib/abstractions/crypto.service'; 
+import { EnvironmentService } from 'jslib/abstractions/environment.service'; 
+import { EventService } from 'jslib/abstractions/event.service'; 
+import { ExportService } from 'jslib/abstractions/export.service'; 
+import { FolderService } from 'jslib/abstractions/folder.service'; 
+import { I18nService } from 'jslib/abstractions/i18n.service'; 
+import { MessagingService } from 'jslib/abstractions/messaging.service'; 
+import { NotificationsService } from 'jslib/abstractions/notifications.service'; 
+import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service'; 
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service'; 
+import { PolicyService } from 'jslib/abstractions/policy.service'; 
+import { SearchService as SearchServiceAbstraction } from 'jslib/abstractions/search.service'; 
+import { SettingsService } from 'jslib/abstractions/settings.service'; 
+import { StateService as StateServiceAbstraction } from 'jslib/abstractions/state.service'; 
+import { StorageService } from 'jslib/abstractions/storage.service'; 
+import { SyncService } from 'jslib/abstractions/sync.service'; 
+import { TokenService } from 'jslib/abstractions/token.service'; 
+import { TotpService } from 'jslib/abstractions/totp.service'; 
+import { UserService } from 'jslib/abstractions/user.service'; 
+import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service'; 
+ 
+import { AutofillService } from '../../services/abstractions/autofill.service'; 
+import BrowserMessagingService from '../../services/browserMessaging.service'; 
+ 
+import { ConstantsService } from 'jslib/services/constants.service'; 
+import { SearchService } from 'jslib/services/search.service'; 
+import { StateService } from 'jslib/services/state.service'; 
+ 
+import { PopupSearchService } from './popup-search.service'; 
+import { PopupUtilsService } from './popup-utils.service'; 
+ 
+import { AuthService } from '../../services/auth.service'; 
+ 
+function getBgService<T>(service: string) { 
+    return (): T => { 
+        const page = BrowserApi.getBackgroundPage(); 
+        return page ? page.bitwardenMain[service] as T : null; 
+    }; 
+} 
+ 
+export const stateService = new StateService(); 
+export const messagingService = new BrowserMessagingService(); 
+export const cozyClientService = new CozyClientService(getBgService<EnvironmentService>('environmentService')(), 
+    getBgService<ApiService>('apiService')()); 
+export const cozySanitizeUrlService = new CozySanitizeUrlService();
+export const konnectorsService = new KonnectorsService(getBgService<CipherService>('cipherService')(), 
+    getBgService<StorageService>('storageService')(), getBgService<SettingsService>('settingsService')(), 
+    cozyClientService); 
+export const authService = getBgService<AuthService>('authService')(); 
+ 
+// See https://github.com/cozy/cozy-keys-browser/pull/70 to have more context 
+// about why we do this 
+authService.setMessagingService(messagingService); 
+export const searchService = new PopupSearchService(getBgService<SearchService>('searchService')(), 
+    getBgService<CipherService>('cipherService')()); 
+ 
+export function initFactory(i18nService: I18nService, storageService: StorageService, 
+    popupUtilsService: PopupUtilsService): Function { 
+    return async () => { 
+        if (!popupUtilsService.inPopup(window)) { 
+            window.document.body.classList.add('body-full'); 
+        } else if (window.screen.availHeight < 600) { 
+            window.document.body.classList.add('body-xs'); 
+        } else if (window.screen.availHeight <= 800) { 
+            window.document.body.classList.add('body-sm'); 
+        } 
+ 
+        if (BrowserApi.getBackgroundPage() != null) { 
+            stateService.save(ConstantsService.disableFaviconKey, 
+                await storageService.get<boolean>(ConstantsService.disableFaviconKey)); 
+ 
+            let theme = await storageService.get<string>(ConstantsService.themeKey); 
+            if (theme == null) { 
+                theme = 'light'; 
+            } 
+            window.document.documentElement.classList.add('locale_' + i18nService.translationLocale); 
+            window.document.documentElement.classList.add('theme_' + theme); 
+ 
+            authService.init(); 
+        } 
+    }; 
+} 
+ 
+@NgModule({ 
+    imports: [ 
+        ToasterModule, 
+    ], 
+    declarations: [], 
+    providers: [ 
+        ValidationService, 
+        AuthGuardService, 
+        LaunchGuardService, 
+        PopupUtilsService, 
+        BroadcasterService, 
+        { provide: CozyClientService, useValue: cozyClientService }, 
+        { provide: CozySanitizeUrlService, useValue: cozySanitizeUrlService },
+        { provide: KonnectorsService, useValue: konnectorsService }, 
+        { provide: MessagingService, useValue: messagingService }, 
+        { provide: AuthServiceAbstraction, useValue: authService }, 
+        { provide: StateServiceAbstraction, useValue: stateService }, 
+        { provide: SearchServiceAbstraction, useValue: searchService }, 
+        { provide: AuditService, useFactory: getBgService<AuditService>('auditService'), deps: [] }, 
+        { provide: CipherService, useFactory: getBgService<CipherService>('cipherService'), deps: [] }, 
+        { 
+            provide: CryptoFunctionService, 
+            useFactory: getBgService<CryptoFunctionService>('cryptoFunctionService'), 
+            deps: [], 
+        }, 
+        { provide: FolderService, useFactory: getBgService<FolderService>('folderService'), deps: [] }, 
+        { provide: CollectionService, useFactory: getBgService<CollectionService>('collectionService'), deps: [] }, 
+        { provide: EnvironmentService, useFactory: getBgService<EnvironmentService>('environmentService'), deps: [] }, 
+        { provide: TotpService, useFactory: getBgService<TotpService>('totpService'), deps: [] }, 
+        { provide: TokenService, useFactory: getBgService<TokenService>('tokenService'), deps: [] }, 
+        { provide: I18nService, useFactory: getBgService<I18nService>('i18nService'), deps: [] }, 
+        { provide: CryptoService, useFactory: getBgService<CryptoService>('cryptoService'), deps: [] }, 
+        { provide: EventService, useFactory: getBgService<EventService>('eventService'), deps: [] }, 
+        { provide: PolicyService, useFactory: getBgService<PolicyService>('policyService'), deps: [] }, 
+        { 
+            provide: PlatformUtilsService, 
+            useFactory: getBgService<PlatformUtilsService>('platformUtilsService'), 
+            deps: [], 
+        }, 
+        { 
+            provide: PasswordGenerationService, 
+            useFactory: getBgService<PasswordGenerationService>('passwordGenerationService'), 
+            deps: [], 
+        }, 
+        { provide: ApiService, useFactory: getBgService<ApiService>('apiService'), deps: [] }, 
+        { provide: SyncService, useFactory: getBgService<SyncService>('syncService'), deps: [] }, 
+        { provide: UserService, useFactory: getBgService<UserService>('userService'), deps: [] }, 
+        { provide: SettingsService, useFactory: getBgService<SettingsService>('settingsService'), deps: [] }, 
+        { provide: StorageService, useFactory: getBgService<StorageService>('storageService'), deps: [] }, 
+        { provide: AppIdService, useFactory: getBgService<AppIdService>('appIdService'), deps: [] }, 
+        { provide: AutofillService, useFactory: getBgService<AutofillService>('autofillService'), deps: [] }, 
+        { provide: ExportService, useFactory: getBgService<ExportService>('exportService'), deps: [] }, 
+        { 
+            provide: VaultTimeoutService, 
+            useFactory: getBgService<VaultTimeoutService>('vaultTimeoutService'), 
+            deps: [], 
+        }, 
+        { 
+            provide: NotificationsService, 
+            useFactory: getBgService<NotificationsService>('notificationsService'), 
+            deps: [], 
+        }, 
+        { 
+            provide: APP_INITIALIZER, 
+            useFactory: initFactory, 
+            deps: [I18nService, StorageService, PopupUtilsService], 
+            multi: true, 
+        }, 
+        { 
+            provide: LOCALE_ID, 
+            useFactory: () => getBgService<I18nService>('i18nService')().translationLocale, 
+            deps: [], 
+        }, 
+    ], 
+}) 
+export class ServicesModule { 
+} 


### PR DESCRIPTION
Url handling in login forms is now using cozy 'state of the art' code from cozy-libs

- Code does not try to remove dashes on custom domains (other than `mycozy` ones) anymore
- An error is now displayed when the user misspell `cozy` for `cosy`
- url handling code is now common to extension login panel and inPageMenu