### PR TITLE
Feat/improve login url handling

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -438,6 +438,9 @@
   "noEmailAsCozyUrl": {
     "message": "The Cozy URL is not your email"
   },
+  "hasMispelledCozy": {
+    "message": "Woops, the address is not correct. Try with \"cozy\" with a \"z\"!"
+  },
   "masterPassRequired": {
     "message": "Cozy password is required."
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -435,6 +435,9 @@
   "noEmailAsCozyUrl": {
     "message": "L'URL de votre Cozy n'est pas votre email"
   },
+  "hasMispelledCozy": {
+    "message": "Oups, ce n'est pas la bonne adresse. Essayez d'écrire \"cozy\" avec un \"z\" !"
+  },
   "masterPassRequired": {
     "message": "Le mot de passe du Cozy est requis."
   },

--- a/src/inPageMenu/loginMenu.js
+++ b/src/inPageMenu/loginMenu.js
@@ -3,6 +3,7 @@ require('./loginMenu.scss');
 import { AuthService } from 'jslib/abstractions/auth.service';
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { Utils } from 'jslib/misc/utils';
+import { CozySanitizeUrlService } from '../popup/services/cozySanitizeUrl.service';
 
 
 /* --------------------------------------------------------------------- */
@@ -267,21 +268,9 @@ function sanitizeUrlInput(inputUrl) {
     if (inputUrl.includes('@')) {
         throw new Error('noEmailAsCozyUrl');
     }
-    // String sanitize
-    inputUrl = inputUrl.trim().toLowerCase();
-    inputUrl = inputUrl.replace(/\/+$/, '') // remove trailing '/' that the user might have inserted by ex when pasting a url for his cozy adress
-
-    // Extract protocol
-    const regexpProtocol = /^(https?:\/\/)?(www\.)?/;
-    const protocolMatches = inputUrl.match(regexpProtocol);
-    const protocol = protocolMatches[1] ? protocolMatches[1] : 'https://';
-    inputUrl = inputUrl.replace(regexpProtocol, '');
-    // Handle url with app slug or with no domain
-    const regexpFQDN = /^([a-z0-9]+)(?:-[a-z0-9]+)?(?:\.(.*))?$/;
-    const matches = inputUrl.match(regexpFQDN);
-    const cozySlug = matches[1];
-    const domain = matches[2] ? matches[2] : 'mycozy.cloud';
-    return `${protocol}${cozySlug}.${domain}`;
+    
+    const cozySanitizeUrlService = new CozySanitizeUrlService();
+    return cozySanitizeUrlService.normalizeURL(inputUrl, cozySanitizeUrlService.cozyDomain);
 }
 
 

--- a/src/inPageMenu/loginMenu.js
+++ b/src/inPageMenu/loginMenu.js
@@ -238,7 +238,8 @@ async function submit() {
     } catch (e) {
     const translatableMessages = [
         'cozyUrlRequired',
-        'noEmailAsCozyUrl'
+        'noEmailAsCozyUrl',
+        'hasMispelledCozy'
     ]
 
     if (translatableMessages.includes(e.message)) {
@@ -285,6 +286,12 @@ function sanitizeUrlInput(inputUrl) {
     }
     
     const cozySanitizeUrlService = new CozySanitizeUrlService();
+
+    // Prevent mycosy instead of mycozy
+    if (cozySanitizeUrlService.hasMispelledCozy(inputUrl)){
+        throw new Error('hasMispelledCozy');
+    }
+    
     return cozySanitizeUrlService.normalizeURL(inputUrl, cozySanitizeUrlService.cozyDomain);
 }
 

--- a/src/popup/accounts/login.component.spec.ts
+++ b/src/popup/accounts/login.component.spec.ts
@@ -55,4 +55,15 @@ describe('url input', () => {
         const url = loginComponent.sanitizeUrlInput(inputUrl);
         expect(url).toEqual('https://on-premise.cloud');
     });
+    it(`should throw if user write 'mycosy' instead of 'mycozy'`, () => {
+        const inputUrl = 'https://claude.mycosy.cloud';
+        expect(() => {
+            loginComponent.sanitizeUrlInput(inputUrl);
+        }).toThrow(new Error('hasMispelledCozy'));
+    });
+    it(`should accept real '*cosy*' url`, () => {
+        const inputUrl = 'https://claude.realdomaincosy.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://claude.realdomaincosy.cloud');
+    });
 });

--- a/src/popup/accounts/login.component.spec.ts
+++ b/src/popup/accounts/login.component.spec.ts
@@ -1,7 +1,8 @@
+import { CozySanitizeUrlService } from '../services/cozySanitizeUrl.service';
 import { LoginComponent } from './login.component';
 
 describe('url input', () => {
-    const loginComponent = new LoginComponent(null, null, null, null, null, null, null, null);
+    const loginComponent = new LoginComponent(null, null, null, null, null, null, null, null, new CozySanitizeUrlService());
     it('should return undefined if the input is empty', () => {
         const inputUrl = '';
         expect(() => {
@@ -38,5 +39,20 @@ describe('url input', () => {
         const inputUrl = 'http://claude.cozy.tools:8080';
         const url = loginComponent.sanitizeUrlInput(inputUrl);
         expect(url).toEqual('http://claude.cozy.tools:8080');
+    });
+    it('should not try to remove slug if present and url has a custom domain', () => {
+        const inputUrl = 'claude-drive.on-premise.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://claude-drive.on-premise.cloud');
+    });
+    it('should return the correct url if domains contains a dash', () => {
+        const inputUrl = 'claude.on-premise.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://claude.on-premise.cloud');
+    });
+    it('should return the correct url if domains contains a dash and cozy is installed on domain root', () => {
+        const inputUrl = 'https://on-premise.cloud';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://on-premise.cloud');
     });
 });

--- a/src/popup/accounts/login.component.ts
+++ b/src/popup/accounts/login.component.ts
@@ -16,6 +16,7 @@ import { AuthResult } from 'jslib/models/domain/authResult';
 import { ConstantsService } from 'jslib/services/constants.service';
 
 import BrowserMessagingService from '../../services/browserMessaging.service';
+import { CozySanitizeUrlService } from "../services/cozySanitizeUrl.service";
 
 const messagingService = new BrowserMessagingService();
 
@@ -63,7 +64,8 @@ export class LoginComponent implements OnInit {
     constructor(protected authService: AuthService, protected router: Router,
         protected platformUtilsService: PlatformUtilsService, protected i18nService: I18nService,
         protected syncService: SyncService, private storageService: StorageService,
-        protected stateService: StorageService, protected environmentService: EnvironmentService) {
+        protected stateService: StorageService, protected environmentService: EnvironmentService,
+        protected cozySanitizeUrlService: CozySanitizeUrlService) {
 
             this.authService = authService;
             this.router = router;
@@ -102,21 +104,8 @@ export class LoginComponent implements OnInit {
         if (inputUrl.includes('@')) {
             throw new Error('noEmailAsCozyUrl');
         }
-        // String sanitize
-        inputUrl = inputUrl.trim().toLowerCase();
-        inputUrl = inputUrl.replace(/\/+$/, ''); // remove trailing '/'
-
-        // Extract protocol
-        const regexpProtocol = /^(https?:\/\/)?(www\.)?/;
-        const protocolMatches = inputUrl.match(regexpProtocol);
-        const protocol = protocolMatches[1] ? protocolMatches[1] : 'https://';
-        inputUrl = inputUrl.replace(regexpProtocol, '');
-        // Handle url with app slug or with no domain
-        const regexpFQDN = /^([a-z0-9]+)(?:-[a-z0-9]+)?(?:\.(.*))?$/;
-        const matches = inputUrl.match(regexpFQDN);
-        const cozySlug = matches[1];
-        const domain = matches[2] ? matches[2] : 'mycozy.cloud';
-        return `${protocol}${cozySlug}.${domain}`;
+        
+        return this.cozySanitizeUrlService.normalizeURL(inputUrl, this.cozySanitizeUrlService.cozyDomain);
     }
 
     async submit() {

--- a/src/popup/accounts/login.component.ts
+++ b/src/popup/accounts/login.component.ts
@@ -105,6 +105,10 @@ export class LoginComponent implements OnInit {
             throw new Error('noEmailAsCozyUrl');
         }
         
+        if (this.cozySanitizeUrlService.hasMispelledCozy(inputUrl)){
+            throw new Error('hasMispelledCozy');
+        }
+        
         return this.cozySanitizeUrlService.normalizeURL(inputUrl, this.cozySanitizeUrlService.cozyDomain);
     }
 

--- a/src/popup/accounts/login.component.ts
+++ b/src/popup/accounts/login.component.ts
@@ -171,9 +171,17 @@ export class LoginComponent implements OnInit {
                 }
             }
         } catch (e) {
-            if (e.message === 'cozyUrlRequired' || e.message === 'noEmailAsCozyUrl') {
+            const translatableMessages = [
+                'cozyUrlRequired',
+                'noEmailAsCozyUrl',
+                'hasMispelledCozy'
+            ]
+            
+            if (translatableMessages.includes(e.message)) {
                 this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
                     this.i18nService.t(e.message));
+            } else {
+                this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'), '');
             }
         }
     }

--- a/src/popup/services/cozySanitizeUrl.service.ts
+++ b/src/popup/services/cozySanitizeUrl.service.ts
@@ -1,0 +1,36 @@
+/*
+    This code is from https://github.com/cozy/cozy-libs/blob/ff41af377c94d8ab5e34ffe91984bb1b1efd3b36/packages/cozy-authentication/src/steps/SelectServer.jsx#L194
+*/
+export class CozySanitizeUrlService {
+    public cozyDomain = '.mycozy.cloud'
+
+    constructor() {}
+
+    protected appendDomain = (value: string, domain: string) =>
+        /\./.test(value) ? value : `${value}${domain}`;
+
+    protected prependProtocol = (value: string) =>
+        /^http(s)?:\/\//.test(value) ? value : `https://${value}`;
+
+    protected removeAppSlug = (value: string) => {
+        const matchedSlugs = /^https?:\/\/\w+(-\w+)\./gi.exec(value);
+
+        return matchedSlugs ? value.replace(matchedSlugs[1], '') : value;
+    };
+
+    normalizeURL = (value: string, defaultDomain: string): string => {
+        const valueWithProtocol = this.prependProtocol(value);
+        const valueWithProtocolAndDomain = this.appendDomain(
+            valueWithProtocol,
+            defaultDomain
+        );
+
+        const isDefaultDomain = new RegExp(`${defaultDomain}$`).test(
+            valueWithProtocolAndDomain
+        );
+        
+        return isDefaultDomain
+            ? this.removeAppSlug(valueWithProtocolAndDomain)
+            : valueWithProtocolAndDomain;
+    };
+}

--- a/src/popup/services/cozySanitizeUrl.service.ts
+++ b/src/popup/services/cozySanitizeUrl.service.ts
@@ -6,6 +6,8 @@ export class CozySanitizeUrlService {
 
     constructor() {}
 
+    hasMispelledCozy = (value: string): boolean => /\.mycosy\./.test(value);
+    
     protected appendDomain = (value: string, domain: string) =>
         /\./.test(value) ? value : `${value}${domain}`;
 

--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -15,6 +15,7 @@ import { ValidationService } from 'jslib/angular/services/validation.service';
 import { BrowserApi } from '../../browser/browserApi';
 
 import { CozyClientService } from './cozyClient.service';
+import { CozySanitizeUrlService } from './cozySanitizeUrl.service';
 import { KonnectorsService } from './konnectors.service';
 
 import { ApiService } from 'jslib/abstractions/api.service';
@@ -68,6 +69,7 @@ export const stateService = new StateService();
 export const messagingService = new BrowserMessagingService();
 export const cozyClientService = new CozyClientService(getBgService<EnvironmentService>('environmentService')(),
     getBgService<ApiService>('apiService')());
+export const cozySanitizeUrlService = new CozySanitizeUrlService();
 export const konnectorsService = new KonnectorsService(getBgService<CipherService>('cipherService')(),
     getBgService<StorageService>('storageService')(), getBgService<SettingsService>('settingsService')(),
     cozyClientService);
@@ -118,6 +120,7 @@ export function initFactory(i18nService: I18nService, storageService: StorageSer
         PopupUtilsService,
         BroadcasterService,
         { provide: CozyClientService, useValue: cozyClientService },
+        { provide: CozySanitizeUrlService, useValue: cozySanitizeUrlService },
         { provide: KonnectorsService, useValue: konnectorsService },
         { provide: MessagingService, useValue: messagingService },
         { provide: AuthServiceAbstraction, useValue: authService },


### PR DESCRIPTION
Url handling in login forms is now using cozy 'state of the art' code from cozy-libs

- Code does not try to remove dashes on custom domains (other than mycozy ones) anymore
- An error is now displayed when the user misspell cozy for cosy
- url handling code is now common to extension login panel and inPageMenu