### PR TITLE
fix: change password hints to prevent ambiguity on which password to use

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,7 +47,7 @@
     "message": "Address of my Cozy"
   },
   "masterPass": {
-    "message": "My Cozy password"
+    "message": "Password"
   },
   "masterPassDesc": {
     "message": "The master password is the password you use to access your Cozy. It is very important that you do not forget your master password. There is no way to recover the password in the event that you forget it."

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -47,7 +47,7 @@
     "message": "Adresse de mon Cozy"
   },
   "masterPass": {
-    "message": "Mot de passe de mon Cozy"
+    "message": "Mot de passe"
   },
   "masterPassDesc": {
     "message": "Le mot de passe maître est le mot de passe que vous utilisez pour accéder à votre Cozy. Il est très important de ne pas l'oublier. Il n'existe aucun moyen de le récupérer si vous le perdez."


### PR DESCRIPTION
Some users have to use their organization password and not their "cozy" password (OIDC login) . The previous wording would introduce ambiguity (cozy password vs organization password).