### PR TITLE
fix: handle trailing slash in cozy address

### DIFF
--- a/src/popup/accounts/login.component.spec.ts
+++ b/src/popup/accounts/login.component.spec.ts
@@ -66,4 +66,9 @@ describe('url input', () => {
         const url = loginComponent.sanitizeUrlInput(inputUrl);
         expect(url).toEqual('https://claude.realdomaincosy.cloud');
     });
+    it(`should remove trailing / in url`, () => {
+        const inputUrl = 'https://claude.realdomaincosy.cloud/';
+        const url = loginComponent.sanitizeUrlInput(inputUrl);
+        expect(url).toEqual('https://claude.realdomaincosy.cloud');
+    });
 });

--- a/src/popup/services/cozySanitizeUrl.service.ts
+++ b/src/popup/services/cozySanitizeUrl.service.ts
@@ -20,10 +20,13 @@ export class CozySanitizeUrlService {
         return matchedSlugs ? value.replace(matchedSlugs[1], '') : value;
     };
 
+    protected removeTrailingSlash = (value: string) => value.replace(/\/$/, "");
+
     normalizeURL = (value: string, defaultDomain: string): string => {
         const valueWithProtocol = this.prependProtocol(value);
+        const valueWithoutTrailingSlash = this.removeTrailingSlash(valueWithProtocol);
         const valueWithProtocolAndDomain = this.appendDomain(
-            valueWithProtocol,
+            valueWithoutTrailingSlash,
             defaultDomain
         );
 


### PR DESCRIPTION
Having a trailing slash in the cozy address would produce a bad vault
url containing two successive slashes (`//`)

This fix remove the trailing slash from the cozy address so only one is
present in the final vault url