### PR TITLE
Fix/reword cozy password

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -348,7 +348,7 @@
     "message": "Authentication"
   },
   "yourVaultIsLocked": {
-    "message": "Your vault is locked, confirm your Cozy password to continue."
+    "message": "Your vault is locked, confirm your password to continue."
   },
   "unlock": {
     "message": "Unlock"
@@ -442,7 +442,7 @@
     "message": "Woops, the address is not correct. Try with \"cozy\" with a \"z\"!"
   },
   "masterPassRequired": {
-    "message": "Cozy password is required."
+    "message": "Password is required."
   },
   "masterPassLength": {
     "message": "Master password must be at least 8 characters long."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -161,7 +161,7 @@
     "message": "Account"
   },
   "changeMasterPassword": {
-    "message": "The modification of your password must be done from your Cozy. Do you want to open it now ?"
+    "message": "Change Master Password"
   },
   "fingerprintPhrase": {
     "message": "Fingerprint Phrase",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -161,7 +161,7 @@
     "message": "Compte"
   },
   "changeMasterPassword": {
-    "message": "Changer le mot de passe mon Cozy"
+    "message": "Changer le mot de passe"
   },
   "fingerprintPhrase": {
     "message": "Phrase d'empreinte",
@@ -348,7 +348,7 @@
     "message": "Authentification"
   },
   "yourVaultIsLocked": {
-    "message": "Votre coffre est verrouillé, confirmez votre mot de passe Cozy pour continuer."
+    "message": "Votre coffre est verrouillé, confirmez votre mot de passe pour continuer."
   },
   "unlock": {
     "message": "Déverrouiller"
@@ -442,7 +442,7 @@
     "message": "Oups, ce n'est pas la bonne adresse. Essayez d'écrire \"cozy\" avec un \"z\" !"
   },
   "masterPassRequired": {
-    "message": "Le mot de passe du Cozy est requis."
+    "message": "Le mot de passe est requis."
   },
   "masterPassLength": {
     "message": "Le mot de passe maître doit au moins contenir 8 caractères."


### PR DESCRIPTION
Remove references to `Cozy password` to remove ambiguity between cozy's password and organization's password

Change wording for english version of `changeMasterPassword` message that is redundant with `changeMasterPasswordConfirmation`
- `changeMasterPassword` does not need to be so detailed as it is used in a menu label and a dialog title
- `changeMasterPasswordConfirmation` is displayed in the confirmation dialog's content