### PR TITLE
feat: bump version to 1.54.4

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extName__",
   "short_name": "__MSG_appName__",
-  "version": "1.54.2",
+  "version": "1.54.4",
   "description": "__MSG_extDesc__",
   "default_locale": "en",
   "author": "Cozy Cloud",


### PR DESCRIPTION
1.54.3 already exists I don't know why it has not been versioned. So new version should be 1.54.4