### PR TITLE
fix: display correct Card subTitle even if some date parts are missing

### DIFF
--- a/src/popup/components/ciphers-list.component.spec.ts
+++ b/src/popup/components/ciphers-list.component.spec.ts
@@ -1,0 +1,169 @@
+import { CipherType } from 'jslib-common/enums/cipherType';
+import { CardView } from "jslib-common/models/view";
+import { CipherView } from 'jslib-common/models/view/cipherView';
+import { CiphersListComponent } from "./ciphers-list.component";
+
+describe('CiphersListComponent', () => {
+    describe('getSubtitle', () => {
+        describe('when CipherType.Card', () => {
+            const ciphersListComponent = new CiphersListComponent();
+        
+            it(`should return correct subtitle when cipher info is complete`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = '2021';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789, 07/21');
+            });
+
+            it(`should handle year with only 2 digits`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = '21';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789, 07/21');
+            });
+
+            it(`should show '07/__' in the date part when cipher info is missing year`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789, 07/__');
+            });
+
+            it(`should show '__/21' in the date part when cipher info is missing month`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789, 07/__');
+            });
+
+            it(`should not show the date part when cipher info is missing month and year`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789');
+            });
+
+            it(`should show '07/__' in the date part when cipher info has bad year format ('ABCD')`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = 'ABCD';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789, 07/__');
+            });
+
+            it(`should show '07/__' in the date part when cipher info has bad year format ('021')`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = '021';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789, 07/__');
+            });
+
+            it(`should show '07/__' in the date part when cipher info has bad year format ('20211')`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = '20211';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, *6789, 07/__');
+            });
+
+            it(`should only show the date part when cipher info is missing card brand and card number`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = '2021';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('07/21');
+            });
+
+            it(`should not show card number if missing`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.brand = 'Visa';
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = '2021';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('Visa, 07/21');
+            });
+
+            it(`should not show card brand if missing`, () => {
+                const cipherView = new CipherView();
+                cipherView.type = CipherType.Card;
+                
+                cipherView.card = new CardView();
+                cipherView.card.number = '123456789';
+                cipherView.card.expMonth = '7';
+                cipherView.card.expYear = '2021';
+
+                expect(
+                  ciphersListComponent.getSubtitle(cipherView)
+                ).toEqual('*6789, 07/21');
+            });
+        });
+    });
+});

--- a/src/popup/components/ciphers-list.component.ts
+++ b/src/popup/components/ciphers-list.component.ts
@@ -8,6 +8,7 @@ import {
 import { CipherType } from 'jslib-common/enums/cipherType';
 
 import { CipherView } from 'jslib-common/models/view/cipherView';
+import { zeroPadLeftUntilTwoChars } from '../../tools/strings';
 
 @Component({
     selector: 'app-ciphers-list',
@@ -42,8 +43,25 @@ export class CiphersListComponent {
 
     getSubtitle(c: CipherView) {
         if (c.type === CipherType.Card) {
-            return c.subTitle + ',  ' + ('0' + c.card.expMonth).slice(-2) + '/' + c.card.expYear.slice(-2) ;
+            const subTitleParts = [];
+
+            if (c.subTitle) {
+                subTitleParts.push(c.subTitle);
+            }
+
+            const isMonthFormatOk = !!c.card.expMonth;
+            const isYearFormatOk = c.card.expYear?.match(/^(?:\d{2}){1,2}$/g);
+
+            if (isMonthFormatOk || isYearFormatOk) {
+                const month = isMonthFormatOk ? zeroPadLeftUntilTwoChars(c.card.expMonth) : '__';
+                const year = isYearFormatOk ? zeroPadLeftUntilTwoChars(c.card.expYear) : '__';
+
+                subTitleParts.push(`${month}/${year}`);
+            }
+            
+            return subTitleParts.join(', ');
         }
+        
         return c.subTitle;
     }
 }

--- a/src/tools/strings.spec.ts
+++ b/src/tools/strings.spec.ts
@@ -1,0 +1,20 @@
+import { zeroPadLeftUntilTwoChars } from "./strings";
+
+describe('strings', () => {
+    describe('zeroPadLeftUntilTwoChars', () => {
+        it(`should return '00' if the input is empty`, () => {
+            const result = zeroPadLeftUntilTwoChars('');
+            expect(result).toEqual('00');
+        });
+
+        it(`should return '21' if the input is '2021'`, () => {
+            const result = zeroPadLeftUntilTwoChars('2021');
+            expect(result).toEqual('21');
+        });
+
+        it(`should return '21' if the input is '21'`, () => {
+            const result = zeroPadLeftUntilTwoChars('21');
+            expect(result).toEqual('21');
+        });
+    });
+});

--- a/src/tools/strings.ts
+++ b/src/tools/strings.ts
@@ -1,0 +1,3 @@
+export function zeroPadLeftUntilTwoChars(input: string) {
+    return `00${input}`.slice(-2);
+}


### PR DESCRIPTION
Credit Cards subTitles should be displayed correctly even if some parts
of the date are missing or have a wrong format

This PR fixes the following cases:
- Year is missing -> Now displays `01/__`
- Month is missing -> Now displays `__/21`
- Year has wrong format (ex: `ABCD`) -> Now displays `01/__`
- Year has only 2 digits (ex: `21`) -> Now displays `01/21`
- Both year and month are missing -> Now displays only the card type and number
- Card type and card number are missing -> leading comma is not displayed anymore
- Every subTitle parts are missing -> Now displays nothing

Before (display is broken due to exception thrown in code when Year is missing)
![image](https://user-images.githubusercontent.com/1884255/128154894-3070a643-61c7-4e0c-abcb-85768b60f1df.png)

After
![image](https://user-images.githubusercontent.com/1884255/128154822-002a6d19-b39a-43da-9253-945a96e2f090.png)
