### PR TITLE
Feat/add fingerprint dialog

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -164,11 +164,11 @@
     "message": "Change Master Password"
   },
   "fingerprintPhrase": {
-    "message": "Fingerprint Phrase",
+    "message": "Security Code",
     "description": "A 'fingerprint phrase' is a unique word phrase (similar to a passphrase) that a user can use to authenticate their public key with another user, for the purposes of sharing."
   },
   "yourAccountsFingerprint": {
-    "message": "Your account's fingerprint phrase",
+    "message": "Your account's security code",
     "description": "A 'fingerprint phrase' is a unique word phrase (similar to a passphrase) that a user can use to authenticate their public key with another user, for the purposes of sharing."
   },
   "twoStepLogin": {

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -164,11 +164,11 @@
     "message": "Changer le mot de passe"
   },
   "fingerprintPhrase": {
-    "message": "Phrase d'empreinte",
+    "message": "Phrase de sécurité",
     "description": "A 'fingerprint phrase' is a unique word phrase (similar to a passphrase) that a user can use to authenticate their public key with another user, for the purposes of sharing."
   },
   "yourAccountsFingerprint": {
-    "message": "La phrase d'empreinte de votre compte",
+    "message": "La phrase de sécurité de votre compte",
     "description": "A 'fingerprint phrase' is a unique word phrase (similar to a passphrase) that a user can use to authenticate their public key with another user, for the purposes of sharing."
   },
   "logOut": {

--- a/src/popup/settings/settings.component.html
+++ b/src/popup/settings/settings.component.html
@@ -76,6 +76,11 @@
                 <div class="row-main">{{'changeMasterPassword' | i18n}}</div>
                 <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
             </a>
+            <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
+                (click)="fingerprint()">
+                <div class="row-main">{{'fingerprintPhrase' | i18n}}</div>
+                <i class="fa fa-chevron-right fa-lg row-sub-icon" aria-hidden="true"></i>
+            </a>
             <a class="box-content-row settings-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
                 (click)="logOut()">
                 <div class="row-main">{{'logOut' | i18n}}</div>

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -349,6 +349,31 @@ export class SettingsComponent implements OnInit {
         });
     }
 
+    async fingerprint() {
+        const fingerprint = await this.cryptoService.getFingerprint(await this.userService.getUserId());
+        const p = document.createElement('p');
+        p.innerText = this.i18nService.t('yourAccountsFingerprint') + ':';
+        const p2 = document.createElement('p');
+        p2.innerText = fingerprint.join('-');
+        const div = document.createElement('div');
+        div.appendChild(p);
+        div.appendChild(p2);
+
+        const result = await Swal.fire({
+            heightAuto: false,
+            buttonsStyling: false,
+            html: div,
+            showCancelButton: true,
+            cancelButtonText: this.i18nService.t('close'),
+            showConfirmButton: true,
+            confirmButtonText: this.i18nService.t('learnMore'),
+        });
+
+        if (result.value) {
+            this.platformUtilsService.launchUri('https://help.bitwarden.com/article/fingerprint-phrase/');
+        }
+    }
+
     rate() {
         const deviceType = this.platformUtilsService.getDevice();
         BrowserApi.createNewTab((RateUrls as any)[deviceType]);

--- a/src/popup/settings/settings.component.ts
+++ b/src/popup/settings/settings.component.ts
@@ -365,7 +365,7 @@ export class SettingsComponent implements OnInit {
             html: div,
             showCancelButton: true,
             cancelButtonText: this.i18nService.t('close'),
-            showConfirmButton: true,
+            showConfirmButton: false,
             confirmButtonText: this.i18nService.t('learnMore'),
         });
 


### PR DESCRIPTION
The settings entry that allows to display fingerprint was removed in first cozy adaptations

Now that password sharing has been implemented, this setting is reimplemented using original bitwarden code

However there is no FAQ yet on Cozy website that could be a target for the button `learn more` so this button has been disabled until we get a `cozy` url to use for its action