### PR TITLE
Feat/sharing

### DIFF
--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -4,7 +4,6 @@ import { CipherRepromptType } from 'jslib-common/enums/cipherRepromptType';
 import {
     AppIdService,
     AuditService,
-    CipherService,
     CollectionService,
     ConstantsService,
     ContainerService,
@@ -94,6 +93,7 @@ import VaultTimeoutService from '../services/vaultTimeout.service';
 import { MessagingService as MessagingServiceAbstraction } from '../services/abstractions/messaging.service';
 
 /* start Cozy imports */
+import { CipherService } from '../popup/services/cipher.service';
 import { UserService } from '../popup/services/user.service';
 import { BrowserCryptoService as CryptoService } from '../services/browserCrypto.service';
 /* end Cozy imports */
@@ -114,7 +114,7 @@ export default class MainBackground {
     environmentService: EnvironmentServiceAbstraction;
     userService: UserService;
     settingsService: SettingsServiceAbstraction;
-    cipherService: CipherServiceAbstraction;
+    cipherService: CipherService;
     folderService: FolderServiceAbstraction;
     collectionService: CollectionServiceAbstraction;
     vaultTimeoutService: VaultTimeoutServiceAbstraction;

--- a/src/background/main.background.ts
+++ b/src/background/main.background.ts
@@ -15,7 +15,6 @@ import {
     StateService,
     TokenService,
     TotpService,
-    UserService,
 } from 'jslib-common/services';
 import { ConsoleLogService } from 'jslib-common/services/consoleLog.service';
 import { EventService } from 'jslib-common/services/event.service';
@@ -94,6 +93,11 @@ import VaultTimeoutService from '../services/vaultTimeout.service';
 
 import { MessagingService as MessagingServiceAbstraction } from '../services/abstractions/messaging.service';
 
+/* start Cozy imports */
+import { UserService } from '../popup/services/user.service';
+import { BrowserCryptoService as CryptoService } from '../services/browserCrypto.service';
+/* end Cozy imports */
+
 export default class MainBackground {
     messagingService: MessagingServiceAbstraction;
     storageService: StorageServiceAbstraction;
@@ -102,13 +106,13 @@ export default class MainBackground {
     platformUtilsService: PlatformUtilsServiceAbstraction;
     constantsService: ConstantsService;
     consoleLogService: ConsoleLogService;
-    cryptoService: CryptoServiceAbstraction;
+    cryptoService: CryptoService;
     cryptoFunctionService: CryptoFunctionServiceAbstraction;
     tokenService: TokenServiceAbstraction;
     appIdService: AppIdServiceAbstraction;
     apiService: ApiServiceAbstraction;
     environmentService: EnvironmentServiceAbstraction;
-    userService: UserServiceAbstraction;
+    userService: UserService;
     settingsService: SettingsServiceAbstraction;
     cipherService: CipherServiceAbstraction;
     folderService: FolderServiceAbstraction;

--- a/src/popup/services/cipher.service.ts
+++ b/src/popup/services/cipher.service.ts
@@ -1,0 +1,62 @@
+import { ApiService } from 'jslib-common/abstractions/api.service';
+import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { FileUploadService } from 'jslib-common/abstractions/fileUpload.service';
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { SearchService } from 'jslib-common/abstractions/search.service';
+import { SettingsService } from 'jslib-common/abstractions/settings.service';
+import { StorageService } from 'jslib-common/abstractions/storage.service';
+import { UserService } from 'jslib-common/abstractions/user.service';
+import { sequentialize } from 'jslib-common/misc/sequentialize';
+import { CipherView } from 'jslib-common/models/view/cipherView';
+import { CipherService as CipherServiceBase } from 'jslib-common/services/cipher.service';
+
+export class CipherService extends CipherServiceBase {
+    constructor(private localCryptoService: CryptoService, private localUserService: UserService,
+      settingsService: SettingsService, apiService: ApiService,
+      fileUploadService: FileUploadService, storageService: StorageService,
+      i18nService: I18nService, private localSearchService: () => SearchService) {
+        super(localCryptoService,
+          localUserService,
+          settingsService,
+          apiService,
+          fileUploadService,
+          storageService,
+          i18nService,
+          localSearchService);
+    }
+
+    @sequentialize(() => 'getAllDecrypted')
+    async getAllDecrypted(): Promise<CipherView[]> {
+        if (this.decryptedCipherCache != null) {
+            const userId = await this.localUserService.getUserId();
+            if (this.localSearchService != null && (this.localSearchService().indexedEntityId ?? userId) !== userId)
+            {
+                await this.localSearchService().indexCiphers(userId, this.decryptedCipherCache);
+            }
+            return this.decryptedCipherCache;
+        }
+
+        const decCiphers: CipherView[] = [];
+        const hasKey = await this.localCryptoService.hasKey();
+        if (!hasKey) {
+            throw new Error('No key.');
+        }
+
+        const orgKeys = await this.localCryptoService.getOrgKeys();
+        const orgIds = [...orgKeys.keys()];
+
+        const promises: any[] = [];
+        const ciphers = (await this.getAll())
+            .filter(cipher => !cipher.organizationId || orgIds.includes(cipher.organizationId));
+
+        ciphers.forEach(cipher => {
+            promises.push(cipher.decrypt().then(c => decCiphers.push(c)));
+        });
+
+        await Promise.all(promises);
+
+        decCiphers.sort(this.getLocaleSortingFunction());
+        this.decryptedCipherCache = decCiphers;
+        return this.decryptedCipherCache;
+    }
+}

--- a/src/popup/services/sync.service.ts
+++ b/src/popup/services/sync.service.ts
@@ -115,9 +115,13 @@ export class SyncService extends BaseSyncService {
 
         this.localSyncStarted();
 
-        await this.syncUpsertOrganization(notification.organizationId, isEdit);
+        try {
+            await this.syncUpsertOrganization(notification.organizationId, isEdit);
 
-        return super.syncUpsertCipher(notification, isEdit);
+            return super.syncUpsertCipher(notification, isEdit);
+        } catch (e) {
+            return this.localSyncCompleted(false);
+        }
     }
 
     protected async getOrganizationKey(organizationId: string): Promise<string> {
@@ -184,5 +188,11 @@ export class SyncService extends BaseSyncService {
     protected localSyncStarted() {
         this.syncInProgress = true;
         this.localMessagingService.send('syncStarted');
+    }
+
+    protected localSyncCompleted(successfully: boolean): boolean {
+        this.syncInProgress = false;
+        this.localMessagingService.send('syncCompleted', { successfully: successfully });
+        return successfully;
     }
 }

--- a/src/popup/services/sync.service.ts
+++ b/src/popup/services/sync.service.ts
@@ -119,8 +119,9 @@ export class SyncService extends BaseSyncService {
         }
 
         const storedOrganization = await this.localUserService.getOrganization(organizationId);
+        const storedOrganizationkey = await this.localCryptoService.getOrgKey(organizationId);
 
-        if (storedOrganization !== null) {
+        if (storedOrganization !== null && storedOrganizationkey != null) {
             return;
         }
 

--- a/src/popup/services/sync.service.ts
+++ b/src/popup/services/sync.service.ts
@@ -143,10 +143,6 @@ export class SyncService extends BaseSyncService {
     }
 
     protected async syncUpsertOrganization(organizationId: string, isEdit: boolean) {
-        if (isEdit) {
-            return;
-        }
-
         if (!organizationId) {
             return;
         }

--- a/src/popup/services/sync.service.ts
+++ b/src/popup/services/sync.service.ts
@@ -34,14 +34,6 @@ let isfullSyncRunning: boolean = false;
 let fullSyncPromise: Promise<boolean>;
 
 export class SyncService extends BaseSyncService {
-    // We need to store these two service instances here because in the extended
-    // class they are private, meaning we can't access this.userService or
-    // this.storageService otherwise
-    /* tslint:disable-next-line */
-    private _userService: UserService;
-    /* tslint:disable-next-line */
-    private _storageService: StorageService;
-
     constructor(
         userService: UserService,
         apiService: ApiService,
@@ -71,9 +63,6 @@ export class SyncService extends BaseSyncService {
                 sendService,
                 logoutCallback,
             );
-
-            this._userService = userService;
-            this._storageService = storageService;
     }
 
     async setLastSync(date: Date): Promise<any> {

--- a/src/popup/services/user.service.ts
+++ b/src/popup/services/user.service.ts
@@ -1,0 +1,35 @@
+import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { StorageService } from 'jslib-common/abstractions/storage.service';
+import { TokenService } from 'jslib-common/abstractions/token.service';
+import { OrganizationData } from 'jslib-common/models/data/organizationData';
+import { Organization } from 'jslib-common/models/domain/organization';
+import { ProfileOrganizationResponse } from 'jslib-common/models/response/profileOrganizationResponse';
+
+import { UserService as UserServiceBase } from 'jslib-common/services/user.service';
+
+const Keys = {
+    organizationsPrefix: 'organizations_',
+};
+
+export class UserService extends UserServiceBase {
+    constructor(
+        tokenService: TokenService,
+        private localStorageService: StorageService) {
+        super(tokenService, localStorageService);
+    }
+
+    async upsertOrganization(organization: ProfileOrganizationResponse) {
+        const userId = await this.getUserId();
+        const organizations = await this.getAllOrganizations();
+        organizations.push(
+            new Organization(
+                new OrganizationData(organization)
+            )
+        );
+        const organizationsData: { [id: string]: OrganizationData; } = {};
+        organizations.forEach(o => {
+            organizationsData[o.id] = o as OrganizationData;
+        });
+        await this.localStorageService.save(Keys.organizationsPrefix + userId, organizationsData);
+    }
+}

--- a/src/services/browserCrypto.service.ts
+++ b/src/services/browserCrypto.service.ts
@@ -1,7 +1,43 @@
+import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
 import { KeySuffixOptions } from 'jslib-common/abstractions/storage.service';
+import { LogService } from 'jslib-common/abstractions/log.service';
+import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { StorageService } from 'jslib-common/abstractions/storage.service';
+
 import { CryptoService } from 'jslib-common/services/crypto.service';
 
+import { ProfileOrganizationResponse } from 'jslib-common/models/response/profileOrganizationResponse';
+
+const Keys = {
+    encOrgKeys: 'encOrgKeys',
+};
+
 export class BrowserCryptoService extends CryptoService {
+    constructor(
+        private localStorageService: StorageService,
+        secureStorageService: StorageService,
+        cryptoFunctionService: CryptoFunctionService,
+        platformUtilService: PlatformUtilsService,
+        logService: LogService
+    ) {
+        super(
+            localStorageService,
+            secureStorageService,
+            cryptoFunctionService,
+            platformUtilService,
+            logService
+        );
+    }
+
+    async upsertOrganizationKey(organization: ProfileOrganizationResponse) {
+        const encOrgKeys = await this.localStorageService.get<any>(Keys.encOrgKeys);
+
+        encOrgKeys[organization.id] = organization.key;
+
+        await this.clearOrgKeys();
+        await this.localStorageService.save(Keys.encOrgKeys, encOrgKeys);
+    }
+
     protected async retrieveKeyFromStorage(keySuffix: KeySuffixOptions) {
         if (keySuffix === 'biometric') {
             await this.platformUtilService.authenticateBiometric();

--- a/src/services/browserCrypto.service.ts
+++ b/src/services/browserCrypto.service.ts
@@ -29,13 +29,13 @@ export class BrowserCryptoService extends CryptoService {
         );
     }
 
-    async upsertOrganizationKey(organization: ProfileOrganizationResponse) {
-        if (organization.key === '') {
+    async upsertOrganizationKey(organizationId: string, key: string) {
+        if (key === '') {
             return;
         }
         const encOrgKeys = await this.localStorageService.get<any>(Keys.encOrgKeys);
 
-        encOrgKeys[organization.id] = organization.key;
+        encOrgKeys[organizationId] = key;
 
         await this.clearOrgKeys();
         await this.localStorageService.save(Keys.encOrgKeys, encOrgKeys);

--- a/src/services/browserCrypto.service.ts
+++ b/src/services/browserCrypto.service.ts
@@ -30,12 +30,21 @@ export class BrowserCryptoService extends CryptoService {
     }
 
     async upsertOrganizationKey(organization: ProfileOrganizationResponse) {
+        if (organization.key === '') {
+            return;
+        }
         const encOrgKeys = await this.localStorageService.get<any>(Keys.encOrgKeys);
 
         encOrgKeys[organization.id] = organization.key;
 
         await this.clearOrgKeys();
         await this.localStorageService.save(Keys.encOrgKeys, encOrgKeys);
+    }
+
+    setOrgKeys(orgs: ProfileOrganizationResponse[]): Promise<{}> {
+        const validOrgs = orgs.filter(org => org.key !== '');
+
+        return super.setOrgKeys(validOrgs);
     }
 
     protected async retrieveKeyFromStorage(keySuffix: KeySuffixOptions) {


### PR DESCRIPTION
This PR retrieves latest changes from `cozy-pass-web` that handle correct display of shared ciphers.

Those commits are cherry picked from the `cozy-pass-web` project and adapted to `cozy-keys-browser` (just a few edits). For reference, each commit contains a link to the original `cozy-pass-web`'s commit.

---
Note that those commit may be used as reference to start the rework of those projects to move common features on `cozy-keys-lib`.

Notable differences:
- jslibs versions are not aligned between both projects (ex: `retrieveKeyFromStorage` only exist on `cozy-keys-browser` side)
- services are not instanciated the same way (hence it is pretty similar)
  - `app.module.ts` on `cozy-pass-web`
  - `app.module.ts` and `main.background.ts` on `cozy-keys-browser`
- Inherited services (from jslib) have not been created in the same place, with same same or with same injected members name. This should be homogenised.
- `fullSync` has small differences on its overriden version