### PR TITLE
fix: logout CozyClient on vault logout

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -94,6 +94,7 @@ export default class RuntimeBackground {
                 break;
             case 'logout':
                 // 1- logout
+                await this.cozyClientService.logout();
                 await this.authService.clear(); // moved from the logout to avoid potential infinite loop
                 await this.main.logout(msg.expired);
                 // 2- ask all frames of all tabs to activate login-in-page-menu

--- a/src/popup/services/cozyClient.service.ts
+++ b/src/popup/services/cozyClient.service.ts
@@ -96,4 +96,10 @@ export class CozyClientService {
         }
         return url.toString();
     }
+
+    async logout() {
+        const client = await this.getClientInstance();
+
+        await client.logout();
+    }
 }


### PR DESCRIPTION
CozyClient is now correctly logged-out  when vault is logged-out

This fix a bug where flags were not cleared after a logout