### PR TITLE
Fix/flags common instance

### DIFF
--- a/src/cozy/components/flag-conditional/flag-conditional.component.ts
+++ b/src/cozy/components/flag-conditional/flag-conditional.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-// @ts-ignore
-import flag from 'cozy-flags';
+import { CozyClientService } from '../../../popup/services/cozyClient.service';
 
 /**
  * A component that renders its children only if the correct flag is set to TRUE
@@ -17,17 +16,23 @@ export class FlagConditionalComponent implements OnInit, OnDestroy {
 
     isFlagEnabled = false;
 
+    private flag: any = undefined;
+
+    constructor(private cozyClientService: CozyClientService) {
+        this.flag = this.cozyClientService.getFlagLib();
+    }
+
     ngOnDestroy(): void {
-        flag.store.removeListener('change', this.flagChanged.bind(this));
+        this.flag.store.removeListener('change', this.flagChanged.bind(this));
     }
 
     ngOnInit() {
-        flag.store.on('change', this.flagChanged.bind(this));
+        this.flag.store.on('change', this.flagChanged.bind(this));
 
         this.flagChanged();
     }
 
     flagChanged() {
-        this.isFlagEnabled = flag(this.flagname);
+        this.isFlagEnabled = this.flag(this.flagname);
     }
 }

--- a/src/cozy/components/flag-conditional/if-flag.directive.ts
+++ b/src/cozy/components/flag-conditional/if-flag.directive.ts
@@ -1,6 +1,5 @@
 import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
-// @ts-ignore
-import flag from 'cozy-flags';
+import { CozyClientService } from '../../../popup/services/cozyClient.service';
 
 /**
  * A directive that allows to render a component only if the correct flag is set to TRUE
@@ -13,6 +12,8 @@ export class IfFlagDirective implements OnInit, OnDestroy {
   private hasView = false;
   private flagName: string;
 
+  private flag: any = undefined;
+
   @Input() set ifFlag(flagName: string) {
     this.flagName = flagName;
     this.flagChanged();
@@ -20,21 +21,24 @@ export class IfFlagDirective implements OnInit, OnDestroy {
 
   constructor(
     private templateRef: TemplateRef<any>,
-    private viewContainer: ViewContainerRef
-  ) { }
+    private viewContainer: ViewContainerRef,
+    private cozyClientService: CozyClientService 
+  ) {
+    this.flag = this.cozyClientService.getFlagLib();
+  }
 
   ngOnDestroy(): void {
-      flag.store.removeListener('change', this.flagChanged.bind(this));
+      this.flag.store.removeListener('change', this.flagChanged.bind(this));
   }
 
   ngOnInit() {
-      flag.store.on('change', this.flagChanged.bind(this));
+      this.flag.store.on('change', this.flagChanged.bind(this));
 
       this.flagChanged();
   }
 
   flagChanged() {
-      this.isFlagEnabled = flag(this.flagName);
+      this.isFlagEnabled = this.flag(this.flagName);
 
       if (this.isFlagEnabled && !this.hasView) {
           this.viewContainer.createEmbeddedView(this.templateRef);

--- a/src/popup/services/cozyClient.service.ts
+++ b/src/popup/services/cozyClient.service.ts
@@ -102,4 +102,8 @@ export class CozyClientService {
 
         await client.logout();
     }
+
+    getFlagLib() {
+        return flag;
+    }
 }

--- a/src/popup/services/services.module.ts
+++ b/src/popup/services/services.module.ts
@@ -83,8 +83,7 @@ const searchService = isPrivateMode ? null : new PopupSearchService(getBgService
 const passwordRepromptService = isPrivateMode ? null : new PasswordRepromptService(getBgService<I18nService>('i18nService')(),
     getBgService<CryptoService>('cryptoService')(), getBgService<PlatformUtilsService>('platformUtilsService')());
 // r�cup�r� brut lors du merge upstream, � adapter TODO BJA
-const cozyClientService = new CozyClientService(getBgService<EnvironmentService>('environmentService')(),
-    getBgService<ApiService>('apiService')());
+export const cozyClientService = getBgService<CozyClientService>('cozyClientService')();
 export const cozySanitizeUrlService = new CozySanitizeUrlService();
 export const konnectorsService = new KonnectorsService(getBgService<CipherService>('cipherService')(),
     getBgService<StorageService>('storageService')(), getBgService<SettingsService>('settingsService')(),


### PR DESCRIPTION
CozyClientService and Popup are running on different threads and so
imported flag's instance may be different

By using flag imported from CozyClientService on both contexts, we
ensure that components are using same flag instance as
CozyClientService

This fixes a bug where flag context is not refreshed correctly after
doing a logout/login