### PR TITLE
fix: init NotificationService with correct url on login

### DIFF
--- a/src/background/runtime.background.ts
+++ b/src/background/runtime.background.ts
@@ -883,6 +883,7 @@ export default class RuntimeBackground {
     private async loggedinAndUnlocked(command: string) {
         await this.main.setIcon();
         await this.main.refreshBadgeAndMenu(false);
+        this.notificationsService.init(this.environmentService);
         this.notificationsService.updateConnection(command === 'unlocked');
         this.systemService.cancelProcessReload();
 


### PR DESCRIPTION
After a logout, if the user login with a new instance url, then this
new instance url should be used by `NotificationService`