### PR TITLE
fix: handle `getAllDecrypted` case where orgs are not synced yet

### DIFF
--- a/src/popup/services/cipher.service.ts
+++ b/src/popup/services/cipher.service.ts
@@ -43,7 +43,7 @@ export class CipherService extends CipherServiceBase {
         }
 
         const orgKeys = await this.localCryptoService.getOrgKeys();
-        const orgIds = [...orgKeys.keys()];
+        const orgIds = orgKeys ? [...orgKeys.keys()] : [];
 
         const promises: any[] = [];
         const ciphers = (await this.getAll())


### PR DESCRIPTION
On first `getAllDecrypted()` call, orgs may not have been synced yet

In this case `getAllDecrypted` would throw while getting all org ids

This error was non blocking as it was call on `GroupingsComponent` load
to check if Notes (cipher.type === 2) are in the list. As we don't
handle Notes this had no impact other than displaying an error in the
console

Now this case is handled correctly

Mirrored from cozy/cozy-pass-web@60ac62135750380c41521ef7eac3a2ab8acb60b7