### PR TITLE
fix: homogenize usage of `address` instead of `URL`

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -430,13 +430,13 @@
     "message": "Invalid email address."
   },
   "cozyUrlRequired": {
-    "message": "Cozy URL is required"
+    "message": "Cozy address is required"
   },
   "invalidCozyUrl": {
-    "message": "Invalid Cozy URL"
+    "message": "Invalid Cozy address"
   },
   "noEmailAsCozyUrl": {
-    "message": "The Cozy URL is not your email"
+    "message": "The Cozy address is not your email"
   },
   "hasMispelledCozy": {
     "message": "Woops, the address is not correct. Try with \"cozy\" with a \"z\"!"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -430,13 +430,13 @@
     "message": "Adresse e-mail invalide."
   },
   "cozyUrlRequired": {
-    "message": "L'URL du Cozy est requise"
+    "message": "L'adresse du Cozy est requise"
   },
   "invalidCozyUrl": {
-    "message": "URL du Cozy invalide"
+    "message": "Adresse du Cozy invalide"
   },
   "noEmailAsCozyUrl": {
-    "message": "L'URL de votre Cozy n'est pas votre email"
+    "message": "L'adresse de votre Cozy n'est pas votre email"
   },
   "hasMispelledCozy": {
     "message": "Oups, ce n'est pas la bonne adresse. Essayez d'écrire \"cozy\" avec un \"z\" !"


### PR DESCRIPTION
We chose to use `address` instead of `URL` as it is more user friendly

See this discussion for more information : https://github.com/cozy/cozy-pass-mobile/pull/52#discussion_r759374161