### PR TITLE
fix: Use Cozy as sidebar title

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -140,7 +140,7 @@
     }
   },
   "sidebar_action": {
-    "default_title": "Cozy Keys",
+    "default_title": "Cozy",
     "default_panel": "popup/index.html?uilocation=sidebar",
     "default_icon": "images/icon19.png"
   }


### PR DESCRIPTION
"Cozy Keys" was displayed in the side bar, which is not the product name