### PR TITLE
fix: Restore options to enable/disable inPageMenu and connectors suggestions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '16'
+  - '16.15.0'
 services:
   - xvfb
 cache:

--- a/src/popup/settings/options.component.html
+++ b/src/popup/settings/options.component.html
@@ -22,6 +22,15 @@
         <div class="box">
             <div class="box-content">
                 <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                    <label for="disableSuggestions">{{'disableKonnectorsSuggestions' | i18n}}</label>
+                    <input id="disableSuggestions" type="checkbox" (change)="updateKonnectorsSuggestions()" [(ngModel)]="disableKonnectorsSuggestions">
+                </div>
+            </div>
+            <div class="box-footer">{{'disableKonnectorsSuggestionsDesc' | i18n}}</div>
+        </div>
+        <div class="box">
+            <div class="box-content">
+                <div class="box-content-row box-content-row-checkbox" appBoxRow>
                     <label for="inPageMenu">{{'enableInPageMenu' | i18n}}</label>
                     <input id="inPageMenu" type="checkbox" (change)="updateEnableInPageMenu()" [(ngModel)]="enableInPageMenu">
                 </div>

--- a/src/popup/settings/options.component.html
+++ b/src/popup/settings/options.component.html
@@ -21,6 +21,15 @@
     <ng-container *ngIf="showGeneral">
         <div class="box">
             <div class="box-content">
+                <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                    <label for="inPageMenu">{{'enableInPageMenu' | i18n}}</label>
+                    <input id="inPageMenu" type="checkbox" (change)="updateEnableInPageMenu()" [(ngModel)]="enableInPageMenu">
+                </div>
+            </div>
+            <div class="box-footer">{{'addLoginNotificationDesc' | i18n}}</div>
+        </div>
+        <div class="box">
+            <div class="box-content">
                 <div class="box-content-row" appBoxRow>
                     <label for="defaultUriMatch">{{'defaultUriMatchDetection' | i18n}}</label>
                     <select id="defaultUriMatch" name="DefaultUriMatch" [(ngModel)]="defaultUriMatch"


### PR DESCRIPTION
In 8a8cc6442254e64919104d085ddae78d19d41362, we removed by error the option's entries that enable/disable InPage menu and connectors suggestion after creating an eligible cipher

This PR restores those features

Related PRs: #24 and #90 
Related Commit: 8a8cc6442254e64919104d085ddae78d19d41362