### PR TITLE
feat: Prevent spellcheck feature on form fields

### DIFF
--- a/src/inPageMenu/loginMenu.html
+++ b/src/inPageMenu/loginMenu.html
@@ -31,7 +31,7 @@
                         <label class="shadow-label"></label>
                         <div class="box-input">
                             <input id="cozy-url" name="CozyUrl" inputmode="url"
-                                placeholder="ex. https://claude.mycozy.cloud" value="">
+                                placeholder="ex. https://claude.mycozy.cloud" value="" appInputVerbatim>
                         </div>
                     </div>
                 </div>
@@ -45,7 +45,7 @@
                         <label class="shadow-label"></label>
                         <div class="box-input">
                             <input id="master-password" type="password"
-                            placeholder="" value="">
+                            placeholder="" value="" appInputVerbatim>
                             <div id="visi-pwd-btn" class="visibility-btn">
                                 <i class="fa fa-mg fa-eye"></i>
                             </div>
@@ -62,7 +62,7 @@
                         <label class="shadow-label"></label>
                         <div class="box-input">
                             <input id="two-fa-input" type="password"
-                            placeholder="" value="">
+                            placeholder="" value="" appInputVerbatim>
                             <div id="visi-2fa-btn" class="visibility-btn">
                                 <i class="fa fa-mg fa-eye"></i>
                             </div>

--- a/src/popup/settings/folder-add-edit.component.html
+++ b/src/popup/settings/folder-add-edit.component.html
@@ -18,7 +18,7 @@
             <div class="box-content">
                 <div class="box-content-row" appBoxRow>
                     <label for="name">{{'name' | i18n}}</label>
-                    <input id="name" type="text" name="Name" [(ngModel)]="folder.name" [appAutofocus]="!editMode">
+                    <input id="name" type="text" name="Name" [(ngModel)]="folder.name" [appAutofocus]="!editMode" appInputVerbatim>
                 </div>
             </div>
         </div>

--- a/src/popup/vault/add-edit.component.html
+++ b/src/popup/vault/add-edit.component.html
@@ -32,7 +32,7 @@
                 </div>
                 <div class="box-content-row" appBoxRow>
                     <label for="name">{{'name' | i18n}}</label>
-                    <input id="name" type="text" name="Name" [(ngModel)]="cipher.name">
+                    <input id="name" type="text" name="Name" [(ngModel)]="cipher.name" appInputVerbatim>
                 </div>
                 <!-- Login -->
                 <div *ngIf="cipher.type === cipherType.Login">
@@ -77,7 +77,7 @@
                     <div class="box-content-row" appBoxRow>
                         <label for="cardCardholderName">{{'cardholderName' | i18n}}</label>
                         <input id="cardCardholderName" type="text" name="Card.CardCardholderName"
-                            [(ngModel)]="cipher.card.cardholderName">
+                            [(ngModel)]="cipher.card.cardholderName" appInputVerbatim>
                     </div>
                     <div class="box-content-row box-content-row-flex" appBoxRow>
                         <div class="row-main">
@@ -108,7 +108,7 @@
                     <div class="box-content-row" appBoxRow>
                         <label for="cardExpYear">{{'expirationYear' | i18n}}</label>
                         <input id="cardExpYear" type="text" name="Card.ExpYear" [(ngModel)]="cipher.card.expYear"
-                            placeholder="{{'ex' | i18n}} {{currentDate | date: 'yyyy'}}">
+                            placeholder="{{'ex' | i18n}} {{currentDate | date: 'yyyy'}}" appInputVerbatim>
                     </div>
                     <div class="box-content-row box-content-row-flex" appBoxRow>
                         <div class="row-main">
@@ -136,17 +136,17 @@
                     <div class="box-content-row" appBoxRow>
                         <label for="idFirstName">{{'firstName' | i18n}}</label>
                         <input id="idFirstName" type="text" name="Identity.FirstName"
-                            [(ngModel)]="cipher.identity.firstName">
+                            [(ngModel)]="cipher.identity.firstName" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idMiddleName">{{'middleName' | i18n}}</label>
                         <input id="idMiddleName" type="text" name="Identity.MiddleName"
-                            [(ngModel)]="cipher.identity.middleName">
+                            [(ngModel)]="cipher.identity.middleName" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idLastName">{{'lastName' | i18n}}</label>
                         <input id="idLastName" type="text" name="Identity.LastName"
-                            [(ngModel)]="cipher.identity.lastName">
+                            [(ngModel)]="cipher.identity.lastName" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idUsername">{{'username' | i18n}}</label>
@@ -155,7 +155,7 @@
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idCompany">{{'company' | i18n}}</label>
-                        <input id="idCompany" type="text" name="Identity.Company" [(ngModel)]="cipher.identity.company">
+                        <input id="idCompany" type="text" name="Identity.Company" [(ngModel)]="cipher.identity.company" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idSsn">{{'ssn' | i18n}}</label>
@@ -179,39 +179,39 @@
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idPhone">{{'phone' | i18n}}</label>
-                        <input id="idPhone" type="text" name="Identity.Phone" [(ngModel)]="cipher.identity.phone">
+                        <input id="idPhone" type="text" name="Identity.Phone" [(ngModel)]="cipher.identity.phone" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idAddress1">{{'address1' | i18n}}</label>
                         <input id="idAddress1" type="text" name="Identity.Address1"
-                            [(ngModel)]="cipher.identity.address1">
+                            [(ngModel)]="cipher.identity.address1" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idAddress2">{{'address2' | i18n}}</label>
                         <input id="idAddress2" type="text" name="Identity.Address2"
-                            [(ngModel)]="cipher.identity.address2">
+                            [(ngModel)]="cipher.identity.address2" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idAddress3">{{'address3' | i18n}}</label>
                         <input id="idAddress3" type="text" name="Identity.Address3"
-                            [(ngModel)]="cipher.identity.address3">
+                            [(ngModel)]="cipher.identity.address3" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idCity">{{'cityTown' | i18n}}</label>
-                        <input id="idCity" type="text" name="Identity.City" [(ngModel)]="cipher.identity.city">
+                        <input id="idCity" type="text" name="Identity.City" [(ngModel)]="cipher.identity.city" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idState">{{'stateProvince' | i18n}}</label>
-                        <input id="idState" type="text" name="Identity.State" [(ngModel)]="cipher.identity.state">
+                        <input id="idState" type="text" name="Identity.State" [(ngModel)]="cipher.identity.state" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idPostalCode">{{'zipPostalCode' | i18n}}</label>
                         <input id="idPostalCode" type="text" name="Identity.PostalCode"
-                            [(ngModel)]="cipher.identity.postalCode">
+                            [(ngModel)]="cipher.identity.postalCode" appInputVerbatim>
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="idCountry">{{'country' | i18n}}</label>
-                        <input id="idCountry" type="text" name="Identity.Country" [(ngModel)]="cipher.identity.country">
+                        <input id="idCountry" type="text" name="Identity.Country" [(ngModel)]="cipher.identity.country" appInputVerbatim>
                     </div>
                 </div>
             </div>
@@ -316,7 +316,7 @@
             </div>
             <div class="box-content">
                 <div class="box-content-row" appBoxRow>
-                    <textarea id="notes" name="Notes" rows="6" [(ngModel)]="cipher.notes"></textarea>
+                    <textarea id="notes" name="Notes" rows="6" [(ngModel)]="cipher.notes" appInputVerbatim></textarea>
                 </div>
             </div>
         </div>

--- a/src/popup/vault/ciphers.component.html
+++ b/src/popup/vault/ciphers.component.html
@@ -8,7 +8,7 @@
     <div class="search">
         <input type="{{searchTypeSearch ? 'search' : 'text'}}"
             placeholder="{{searchPlaceholder || ('searchVault' | i18n)}}" id="search" [(ngModel)]="searchText"
-            (input)="search(200)" autocomplete="off" appAutofocus>
+            (input)="search(200)" autocomplete="off" appAutofocus appInputVerbatim>
         <i class="fa fa-search" aria-hidden="true"></i>
         <i class="fa fa-close" aria-hidden="true" (click)="emptySearch()"></i>
     </div>

--- a/src/popup/vault/groupings.component.html
+++ b/src/popup/vault/groupings.component.html
@@ -13,7 +13,7 @@
         <input #searchInput type="{{searchTypeSearch ? 'search' : 'text'}}"
             placeholder="{{searchTagClass === 'hideSearchTag' ? ('searchVault' | i18n) : ''}}"
             id="search"
-            [(ngModel)]="searchText" (input)="search(200)" autocomplete="off">
+            [(ngModel)]="searchText" (input)="search(200)" autocomplete="off" appInputVerbatim>
         <i class="fa fa-close" aria-hidden="true" (click)="unActivatePanel()"></i>
     </div>
     <button (click)="openWebApp()" appA11yTitle="{{'popOutNewWindow' | i18n}}">


### PR DESCRIPTION
Everything protected in the vault should be considered as sensible data that should not leak through browser's enhanced spellcheck

So we want to disable spellcheck on cozy-pass fields like password fields, names, urls, notes, address etc

This commit does not handle `send` feature fields as it deactivated and so we are not able to test it. But this should be considered if we implement it in the future

More info: https://www.otto-js.com/news/article/chrome-and-edge-enhanced-spellcheck-features-expose-pii-even-your-passwords

Related issue: bitwarden/desktop#842

___

This PR reflects https://github.com/cozy/cozy-pass-web/pull/84