### PR TITLE
feat: Redirect to CozyPass web onboarding on "forgot password" for OIDC

### DIFF
--- a/src/popup/accounts/login.component.spec.ts
+++ b/src/popup/accounts/login.component.spec.ts
@@ -2,7 +2,7 @@ import { CozySanitizeUrlService } from '../services/cozySanitizeUrl.service';
 import { LoginComponent } from './login.component';
 
 describe('url input', () => {
-    const loginComponent = new LoginComponent(null, null, null, null, null, null, null, null, new CozySanitizeUrlService());
+    const loginComponent = new LoginComponent(null, null, null, null, null, null, null, null, new CozySanitizeUrlService(), null);
     it('should return undefined if the input is empty', () => {
         const inputUrl = '';
         expect(() => {

--- a/src/popup/accounts/login.component.ts
+++ b/src/popup/accounts/login.component.ts
@@ -26,10 +26,6 @@ const Keys = {
 };
 
 const getPassphraseResetURL = (cozyUrl: string) => {
-    // Handle lack of protocol and trailing slash
-    cozyUrl = cozyUrl.startsWith('http') ?
-        cozyUrl : `https://${cozyUrl}`;
-    cozyUrl = cozyUrl.endsWith('/') ? cozyUrl.substring(0, cozyUrl.length - 1) : cozyUrl;
     return `${cozyUrl}/auth/passphrase_reset`;
 };
 
@@ -202,10 +198,12 @@ export class LoginComponent implements OnInit {
             return;
         }
 
+        const loginUrl = this.sanitizeUrlInput(this.cozyUrl);
+
         const browser = window.browser || window.chrome;
         await browser.tabs.create({
             active: true,
-            url: getPassphraseResetURL(this.cozyUrl),
+            url: getPassphraseResetURL(loginUrl),
         });
 
         // Close popup


### PR DESCRIPTION
When the user click on "I forgot my password" link, if this cozy is in
an OIDC context and if the CozyPass onboarding is not done yet, then we
want to redirect to the onboarding instead of the
`/auth/passphrase_reset` route

This behavior is because OIDC users have 2 different passwords, the one
from the OIDC portal, and the one for CozyPass

When the user logs into CozyPass Browser for the first time, they may
not know that they should use a different password from the OIDC portal
so we should not redirect into the portal, but to the CozyPass
onboarding

___

TODO:

- [x] Test the feature using an OIDC cozy when https://github.com/cozy/cozy-stack/pull/3544 is merged