### PR TITLE
fix: Disable `.json (Encrypted)` option in the export screen

### DIFF
--- a/src/popup/settings/export.component.html
+++ b/src/popup/settings/export.component.html
@@ -21,7 +21,12 @@
                     <select id="format" name="Format" [(ngModel)]="format">
                         <option value="json">.json</option>
                         <option value="csv">.csv</option>
+                        <!-- Cozy customization -->
+                        <!-- Remove encrypted_json option until we fix the bug that does not apply encryption on the exported json -->
+                        <!-- TODO: re-enable this when bug is fixed -->
+                        <!--
                         <option value="encrypted_json">.json (Encrypted)</option>
+                        -->
                     </select>
                 </div>
                 <div class="box-content-row box-content-row-flex" appBoxRow>


### PR DESCRIPTION
In the current implementation we use a Cozy override of `ExportService`

During previous merge upstream, we did not apply latest code change from the base class, so the override method still implements the old behaviour

However we received the UI update that was referencing `.json (Encrypted)` option that is not implemented in our version yet

So we deactivate this option until we fix the implementation (this should be done after the in-progress merge upstream)