### PR TITLE
Display notes and papers

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -355,6 +355,9 @@
   "itemInformation": {
     "message": "Item information"
   },
+  "usefulInformation": {
+    "message": "Useful information"
+  },
   "username": {
     "message": "Username"
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1810,6 +1810,9 @@
   "unfavorite": {
     "message": "Unfavorite"
   },
+  "print": {
+    "message": "Print"
+  },
   "removedPassword": {
     "message": "Password removed"
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -358,6 +358,9 @@
   "usefulInformation": {
     "message": "Useful information"
   },
+  "actions": {
+    "message": "Actions"
+  },
   "username": {
     "message": "Username"
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1813,6 +1813,9 @@
   "print": {
     "message": "Print"
   },
+  "download": {
+    "message": "Download"
+  },
   "removedPassword": {
     "message": "Password removed"
   },

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -361,6 +361,9 @@
   "actions": {
     "message": "Actions"
   },
+  "content": {
+    "message": "Content"
+  },
   "username": {
     "message": "Username"
   },

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -361,6 +361,9 @@
   "usefulInformation": {
     "message": "Informations utiles"
   },
+  "actions": {
+    "message": "Actions"
+  },
   "username": {
     "message": "Identifiant"
   },

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -1861,6 +1861,9 @@
   "print": {
     "message": "Imprimer"
   },
+  "download": {
+    "message": "Télécharger"
+  },
   "removedPassword": {
     "message": "Mot de passe supprimé"
   },

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -1858,6 +1858,9 @@
   "unfavorite": {
     "message": "Retirer des favoris"
   },
+  "print": {
+    "message": "Imprimer"
+  },
   "removedPassword": {
     "message": "Mot de passe supprimé"
   },

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -358,6 +358,9 @@
   "itemInformation": {
     "message": "Informations sur l'élément"
   },
+  "usefulInformation": {
+    "message": "Informations utiles"
+  },
   "username": {
     "message": "Identifiant"
   },

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -364,6 +364,9 @@
   "actions": {
     "message": "Actions"
   },
+  "content": {
+    "message": "Contenu"
+  },
   "username": {
     "message": "Identifiant"
   },

--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -351,7 +351,9 @@ li.active .icon-cozy-inline > svg {
 }
 
 .paper-illustration img {
-  height: 128px;
+  height: 100px;
+  max-width: 100%;
+  object-fit: contain;
 }
 
 .icon-pen {

--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -340,6 +340,20 @@ li.active .icon-cozy-inline > svg {
   content: url("../images/icon-file-type-text.png");
 }
 
+.paper-illustration {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #fff;
+  margin-top: 0px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.paper-illustration img {
+  height: 128px;
+}
+
 .icon-pen {
   mask-image: url("../images/icons-16-icon-pen.svg");
   -webkit-mask-image: url("../images/icons-16-icon-pen.svg");

--- a/apps/browser/src/popup/scss/pages.scss
+++ b/apps/browser/src/popup/scss/pages.scss
@@ -219,15 +219,18 @@ app-vault-add-edit,
 app-generator,
 app-vault-attachments {
   .box {
-    /* Cozy custo
+    /* Cozy customization
     margin: 15px 0 25px 0;
     */
     margin-top: 15px;
-    /* end custo */
 
+    /*
     & + .box {
       margin-top: 25px;
     }
+    */
+
+    /* Cozy customization end */
   }
 }
 

--- a/apps/browser/src/vault/popup/components/vault/add-edit.component.html
+++ b/apps/browser/src/vault/popup/components/vault/add-edit.component.html
@@ -30,7 +30,7 @@
     </app-callout>
     <div class="box">
       <h2 class="box-header">
-        {{ "itemInformation" | i18n }}
+        {{ "usefulInformation" | i18n }}
       </h2>
       <div class="box-content">
         <!--

--- a/apps/browser/src/vault/popup/components/vault/view-custom-fields.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view-custom-fields.component.html
@@ -1,8 +1,19 @@
 <ng-container>
+  <!-- Cozy customization; hide "Custom fields" header and remove extra margin for Paper ciphers  -->
+  <!--
   <h2 class="box-header">
+  -->
+  <h2 class="box-header" *ngIf="cipher.type !== cipherType.Paper">
     {{ "customFields" | i18n }}
   </h2>
+  <!--
   <div class="box-content">
+  -->
+  <div
+    class="box-content"
+    [ngStyle]="{ 'margin-top.px': cipher.type !== cipherType.Paper ? 0 : -15 }"
+  >
+    <!-- Cozy customization end -->
     <div class="box-content-row box-content-row-flex" *ngFor="let field of cipher.fields">
       <div class="row-main">
         <span

--- a/apps/browser/src/vault/popup/components/vault/view-custom-fields.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view-custom-fields.component.ts
@@ -2,12 +2,19 @@ import { Component } from "@angular/core";
 
 import { ViewCustomFieldsComponent as BaseViewCustomFieldsComponent } from "@bitwarden/angular/vault/components/view-custom-fields.component";
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
+/* Cozy customization */
+import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
+/* Cozy customization end */
 
 @Component({
   selector: "app-vault-view-custom-fields",
   templateUrl: "view-custom-fields.component.html",
 })
 export class ViewCustomFieldsComponent extends BaseViewCustomFieldsComponent {
+  /* Cozy customization */
+  cipherType = CipherType;
+  /* Cozy customization end */
+
   constructor(eventCollectionService: EventCollectionService) {
     super(eventCollectionService);
   }

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -585,6 +585,9 @@
     </div>
   </div>
   <div class="box list">
+    <h2 class="box-header">
+      {{ "actions" | i18n }}
+    </h2>
     <div class="box-content single-line">
       <button
         type="button"

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -35,6 +35,15 @@
   </div>
 </header>
 <main tabindex="-1" *ngIf="cipher">
+  <!-- Cozy customization -->
+  <div *ngIf="cipher.type === cipherType.Paper" class="paper-illustration">
+    <img
+      [src]="cipher.paper.illustrationUrl"
+      (click)="openWebApp()"
+      (error)="onIllustrationError()"
+    />
+  </div>
+  <!-- Cozy customization end -->
   <div class="box">
     <h2 class="box-header">
       {{ "usefulInformation" | i18n }}

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -716,6 +716,20 @@
         </div>
       </button>
       <!-- Cozy customization end -->
+      <!-- Cozy customization -->
+      <button
+        type="button"
+        class="box-content-row"
+        appStopClick
+        appBlurClick
+        (click)="download()"
+        *ngIf="cipher.type === cipherType.Paper"
+      >
+        <div class="row-main text-primary">
+          <span>{{ "download" | i18n }}</span>
+        </div>
+      </button>
+      <!-- Cozy customization end -->
       <button
         type="button"
         class="box-content-row"

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -37,7 +37,7 @@
 <main tabindex="-1" *ngIf="cipher">
   <div class="box">
     <h2 class="box-header">
-      {{ "itemInformation" | i18n }}
+      {{ "usefulInformation" | i18n }}
     </h2>
     <div class="box-content">
       <div class="box-content-row">

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -702,6 +702,20 @@
           <span>{{ "changeFolder" | i18n }}</span>
         </div>
       </button>
+      <!-- Cozy customization -->
+      <button
+        type="button"
+        class="box-content-row"
+        appStopClick
+        appBlurClick
+        (click)="print()"
+        *ngIf="cipher.type === cipherType.Paper"
+      >
+        <div class="row-main text-primary">
+          <span>{{ "print" | i18n }}</span>
+        </div>
+      </button>
+      <!-- Cozy customization end -->
       <button
         type="button"
         class="box-content-row"

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -646,6 +646,8 @@
           <span>{{ "autoFillAndSave" | i18n }}</span>
         </div>
       </button>
+      <!-- Cozy customization; do not display "clone" action if cipher is a paper" -->
+      <!--
       <button
         type="button"
         class="box-content-row"
@@ -654,6 +656,16 @@
         (click)="clone()"
         *ngIf="!cipher.organizationId && !cipher.isDeleted"
       >
+      -->
+      <button
+        type="button"
+        class="box-content-row"
+        appStopClick
+        appBlurClick
+        (click)="clone()"
+        *ngIf="!cipher.organizationId && !cipher.isDeleted && cipher.type !== cipherType.Paper"
+      >
+        <!-- Cozy customization end -->
         <div class="row-main text-primary">
           <div class="icon text-primary" aria-hidden="true">
             <i class="bwi bwi-files bwi-lg bwi-fw"></i>
@@ -676,7 +688,7 @@
         class="box-content-row"
         appStopClick
         (click)="share()"
-        *ngIf="!cipher.isDeleted"
+        *ngIf="!cipher.isDeleted && cipher.type !== cipherType.Paper"
       >
         <!-- end custo -->
         <div class="row-main text-primary">

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -419,6 +419,15 @@ export class ViewComponent extends BaseViewComponent {
     if (this.cipher.type === CipherType.Paper && this.cipher.paper.type === PaperType.Paper) {
       const hash = `/paper/files/${this.cipher.paper.qualificationLabel}/${this.cipher.id}`;
       window.open(this.cozyClientService.getAppURL("mespapiers", hash));
+    } else if (this.cipher.type === CipherType.Paper && this.cipher.paper.type === PaperType.Note) {
+      const returnUrl = this.cozyClientService.getAppURL(
+        "mespapiers",
+        `/paper/files/${this.cipher.paper.qualificationLabel}`
+      );
+      const destinationUrl = this.cozyClientService.getAppURL("notes", `n/${this.cipher.id}`);
+      const url = new URL(destinationUrl);
+      url.searchParams.set("returnUrl", returnUrl);
+      window.open(url.toString());
     } else {
       const hash = "/vault?action=view&cipherId=" + this.cipherId;
       window.open(this.cozyClientService.getAppURL("passwords", hash));

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -181,6 +181,14 @@ export class ViewComponent extends BaseViewComponent {
     if (this.cipher.isDeleted) {
       return false;
     }
+
+    // Cozy customization
+    if (this.cipher.type === CipherType.Paper) {
+      this.openWebApp();
+      return;
+    }
+    // Cozy customization end
+
     if (!(await super.edit())) {
       return false;
     }

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -40,6 +40,7 @@ import { deleteCipher } from "./cozy-utils";
 import { CozyClientService } from "../../../../popup/services/cozyClient.service";
 import { CAN_SHARE_ORGANIZATION } from "../../../../cozy/flags";
 import { HistoryService } from "../../../../popup/services/history.service";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
 /* eslint-enable */
 /* end Cozy imports */
 
@@ -81,7 +82,8 @@ export class ViewComponent extends BaseViewComponent {
     logService: LogService,
     fileDownloadService: FileDownloadService,
     private cozyClientService: CozyClientService,
-    private historyService: HistoryService
+    private historyService: HistoryService,
+    private syncService: SyncService
   ) {
     super(
       cipherService,
@@ -416,4 +418,13 @@ export class ViewComponent extends BaseViewComponent {
     const hash = "/vault?action=view&cipherId=" + this.cipherId;
     window.open(this.cozyClientService.getAppURL("passwords", hash));
   }
+
+  // Cozy customization
+  async onIllustrationError() {
+    // An illustration URL is valid for 10 minutes. If an illustration URL is expired,
+    // it is very likely that all illustration URLs are expired. So we start a
+    // full sync that will get new illustration URLs.
+    await this.syncService.fullSync(true);
+  }
+  // Cozy customization end
 }

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -41,6 +41,7 @@ import { CozyClientService } from "../../../../popup/services/cozyClient.service
 import { CAN_SHARE_ORGANIZATION } from "../../../../cozy/flags";
 import { HistoryService } from "../../../../popup/services/history.service";
 import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
+import { PaperType } from "@bitwarden/common/enums/paperType";
 /* eslint-enable */
 /* end Cozy imports */
 
@@ -415,8 +416,13 @@ export class ViewComponent extends BaseViewComponent {
   }
 
   openWebApp() {
-    const hash = "/vault?action=view&cipherId=" + this.cipherId;
-    window.open(this.cozyClientService.getAppURL("passwords", hash));
+    if (this.cipher.type === CipherType.Paper && this.cipher.paper.type === PaperType.Paper) {
+      const hash = `/paper/files/${this.cipher.paper.qualificationLabel}/${this.cipher.id}`;
+      window.open(this.cozyClientService.getAppURL("mespapiers", hash));
+    } else {
+      const hash = "/vault?action=view&cipherId=" + this.cipherId;
+      window.open(this.cozyClientService.getAppURL("passwords", hash));
+    }
   }
 
   // Cozy customization

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -443,6 +443,18 @@ export class ViewComponent extends BaseViewComponent {
   }
 
   // Cozy customization
+  async print() {
+    const client = await this.cozyClientService.getClientInstance();
+
+    const printUrl = await client
+      .collection("io.cozy.files")
+      .getDownloadLinkById(this.cipher.id, this.cipher.name);
+
+    window.open(printUrl);
+  }
+  // Cozy customization end
+
+  // Cozy customization
   async onIllustrationError() {
     // An illustration URL is valid for 10 minutes. If an illustration URL is expired,
     // it is very likely that all illustration URLs are expired. So we start a

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -455,6 +455,18 @@ export class ViewComponent extends BaseViewComponent {
   // Cozy customization end
 
   // Cozy customization
+  async download() {
+    const client = await this.cozyClientService.getClientInstance();
+
+    const downloadUrl = await client
+      .collection("io.cozy.files")
+      .getDownloadLinkById(this.cipher.id, this.cipher.name);
+
+    client.collection("io.cozy.files").forceFileDownload(`${downloadUrl}?Dl=1`, this.cipher.name);
+  }
+  // Cozy customization end
+
+  // Cozy customization
   async onIllustrationError() {
     // An illustration URL is valid for 10 minutes. If an illustration URL is expired,
     // it is very likely that all illustration URLs are expired. So we start a

--- a/libs/common/src/models/api/paper.api.ts
+++ b/libs/common/src/models/api/paper.api.ts
@@ -7,6 +7,7 @@ export class PaperApi extends BaseResponse {
   ownerName: string;
   illustrationThumbnailUrl: string;
   illustrationUrl: string;
+  qualificationLabel: string;
   noteContent: string;
 
   constructor(data: any = null) {
@@ -18,6 +19,7 @@ export class PaperApi extends BaseResponse {
     this.ownerName = this.getResponseProperty("OwnerName");
     this.illustrationThumbnailUrl = this.getResponseProperty("IllustrationThumbnailUrl");
     this.illustrationUrl = this.getResponseProperty("IllustrationUrl");
+    this.qualificationLabel = this.getResponseProperty("QualificationLabel");
     this.noteContent = this.getResponseProperty("NoteContent");
   }
 }

--- a/libs/common/src/models/api/paper.api.ts
+++ b/libs/common/src/models/api/paper.api.ts
@@ -6,6 +6,7 @@ export class PaperApi extends BaseResponse {
   type: PaperType;
   ownerName: string;
   illustrationThumbnailUrl: string;
+  illustrationUrl: string;
   noteContent: string;
 
   constructor(data: any = null) {
@@ -16,6 +17,7 @@ export class PaperApi extends BaseResponse {
     this.type = this.getResponseProperty("Type");
     this.ownerName = this.getResponseProperty("OwnerName");
     this.illustrationThumbnailUrl = this.getResponseProperty("IllustrationThumbnailUrl");
+    this.illustrationUrl = this.getResponseProperty("IllustrationUrl");
     this.noteContent = this.getResponseProperty("NoteContent");
   }
 }

--- a/libs/common/src/vault/models/data/paper.data.ts
+++ b/libs/common/src/vault/models/data/paper.data.ts
@@ -6,6 +6,7 @@ export class PaperData {
   type: PaperType;
   ownerName: string;
   illustrationThumbnailUrl: string;
+  illustrationUrl: string;
   noteContent: string;
 
   constructor(data?: PaperApi) {
@@ -16,6 +17,7 @@ export class PaperData {
     this.type = data.type;
     this.ownerName = data.ownerName;
     this.illustrationThumbnailUrl = data.illustrationThumbnailUrl;
+    this.illustrationUrl = data.illustrationUrl;
     this.noteContent = data.noteContent;
   }
 }

--- a/libs/common/src/vault/models/data/paper.data.ts
+++ b/libs/common/src/vault/models/data/paper.data.ts
@@ -7,6 +7,7 @@ export class PaperData {
   ownerName: string;
   illustrationThumbnailUrl: string;
   illustrationUrl: string;
+  qualificationLabel: string;
   noteContent: string;
 
   constructor(data?: PaperApi) {
@@ -18,6 +19,7 @@ export class PaperData {
     this.ownerName = data.ownerName;
     this.illustrationThumbnailUrl = data.illustrationThumbnailUrl;
     this.illustrationUrl = data.illustrationUrl;
+    this.qualificationLabel = data.qualificationLabel;
     this.noteContent = data.noteContent;
   }
 }

--- a/libs/common/src/vault/models/domain/paper.ts
+++ b/libs/common/src/vault/models/domain/paper.ts
@@ -9,6 +9,7 @@ export class Paper extends Domain {
   type: PaperType = null;
   ownerName: string;
   illustrationThumbnailUrl: string;
+  illustrationUrl: string;
   noteContent: string;
 
   constructor(obj?: PaperData) {
@@ -20,6 +21,7 @@ export class Paper extends Domain {
     this.type = obj.type;
     this.ownerName = obj.ownerName;
     this.illustrationThumbnailUrl = obj.illustrationThumbnailUrl;
+    this.illustrationUrl = obj.illustrationUrl;
     this.noteContent = obj.noteContent;
   }
 

--- a/libs/common/src/vault/models/domain/paper.ts
+++ b/libs/common/src/vault/models/domain/paper.ts
@@ -10,6 +10,7 @@ export class Paper extends Domain {
   ownerName: string;
   illustrationThumbnailUrl: string;
   illustrationUrl: string;
+  qualificationLabel: string;
   noteContent: string;
 
   constructor(obj?: PaperData) {
@@ -22,6 +23,7 @@ export class Paper extends Domain {
     this.ownerName = obj.ownerName;
     this.illustrationThumbnailUrl = obj.illustrationThumbnailUrl;
     this.illustrationUrl = obj.illustrationUrl;
+    this.qualificationLabel = obj.qualificationLabel;
     this.noteContent = obj.noteContent;
   }
 

--- a/libs/common/src/vault/models/view/paper.view.ts
+++ b/libs/common/src/vault/models/view/paper.view.ts
@@ -10,6 +10,7 @@ export class PaperView extends ItemView {
   type: PaperType = null;
   ownerName: string = null;
   illustrationThumbnailUrl: string = null;
+  illustrationUrl: string = null;
   noteContent: string = null;
 
   constructor(p?: Paper) {
@@ -21,6 +22,7 @@ export class PaperView extends ItemView {
     this.type = p.type;
     this.ownerName = p.ownerName;
     this.illustrationThumbnailUrl = p.illustrationThumbnailUrl;
+    this.illustrationUrl = p.illustrationUrl;
     this.noteContent = p.noteContent;
   }
 

--- a/libs/common/src/vault/models/view/paper.view.ts
+++ b/libs/common/src/vault/models/view/paper.view.ts
@@ -11,6 +11,7 @@ export class PaperView extends ItemView {
   ownerName: string = null;
   illustrationThumbnailUrl: string = null;
   illustrationUrl: string = null;
+  qualificationLabel: string = null;
   noteContent: string = null;
 
   constructor(p?: Paper) {
@@ -23,6 +24,7 @@ export class PaperView extends ItemView {
     this.ownerName = p.ownerName;
     this.illustrationThumbnailUrl = p.illustrationThumbnailUrl;
     this.illustrationUrl = p.illustrationUrl;
+    this.qualificationLabel = p.qualificationLabel;
     this.noteContent = p.noteContent;
   }
 

--- a/libs/cozy/fields.helper.ts
+++ b/libs/cozy/fields.helper.ts
@@ -2,6 +2,7 @@ import { models } from "cozy-client";
 
 import { FieldType } from "@bitwarden/common/enums/fieldType";
 import { FieldApi } from "@bitwarden/common/models/api/field.api";
+import { Field } from "@bitwarden/common/vault/models/domain/field";
 import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
 
 const {
@@ -17,7 +18,7 @@ const {
   formatContactValue,
 } = models.paper;
 
-const buildField = (name: string, value: string): FieldView => {
+export const buildField = (name: string, value: string): FieldView => {
   const field = new FieldView();
   field.type = FieldType.Text;
   field.name = name;

--- a/libs/cozy/fields.helper.ts
+++ b/libs/cozy/fields.helper.ts
@@ -1,0 +1,90 @@
+import { models } from "cozy-client";
+
+import { FieldType } from "@bitwarden/common/enums/fieldType";
+import { FieldApi } from "@bitwarden/common/models/api/field.api";
+import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
+
+const {
+  formatMetadataQualification,
+  getMetadataQualificationType,
+  getTranslatedNameForDateMetadata,
+  formatDateMetadataValue,
+  getTranslatedNameForInformationMetadata,
+  formatInformationMetadataValue,
+  getTranslatedNameForOtherMetadata,
+  formatOtherMetadataValue,
+  getTranslatedNameForContact,
+  formatContactValue,
+} = models.paper;
+
+const buildField = (name: string, value: string): FieldView => {
+  const field = new FieldView();
+  field.type = FieldType.Text;
+  field.name = name;
+  field.value = value;
+  return field;
+};
+
+export const buildFieldsFromPaper = (i18nService: any, paper: any): FieldView[] => {
+  const fields: FieldView[] = [];
+
+  const qualificationLabels = formatMetadataQualification(paper.metadata);
+  const qualificationLabel = paper.metadata.qualification.label;
+  const lang = i18nService.translationLocale;
+  const f = (a: string) => {
+    return new Date(a).toLocaleString(lang, { year: "numeric", month: "numeric", day: "numeric" });
+  };
+
+  qualificationLabels.forEach((label: { name: string; value: string }) => {
+    const metadataQualificationType = getMetadataQualificationType(label.name);
+    let formattedName;
+    let formattedValue;
+
+    if (metadataQualificationType === "information") {
+      formattedName = getTranslatedNameForInformationMetadata(label.name, {
+        lang,
+        qualificationLabel,
+      });
+      formattedValue = formatInformationMetadataValue(label.value, {
+        lang,
+        name: label.name,
+        qualificationLabel,
+      });
+    } else if (metadataQualificationType === "date") {
+      formattedName = getTranslatedNameForDateMetadata(label.name, { lang });
+      formattedValue = formatDateMetadataValue(label.value, { lang, f });
+    } else if (metadataQualificationType === "other") {
+      formattedName = getTranslatedNameForOtherMetadata(label.name, { lang });
+      formattedValue = formatOtherMetadataValue(label.value, {
+        lang,
+        name: label.name,
+      });
+    } else if (metadataQualificationType === "contact" && paper.contacts.data.length > 0) {
+      formattedName = getTranslatedNameForContact({ lang });
+      formattedValue = formatContactValue(paper.contacts.data);
+    } else {
+      return;
+    }
+
+    const field = buildField(formattedName, formattedValue);
+    fields.push(field);
+  });
+
+  return fields;
+};
+
+export const copyEncryptedFields = (fields: Field[]): FieldApi[] => {
+  const encryptedFields = [];
+
+  for (const field of fields) {
+    encryptedFields.push(
+      new FieldApi({
+        Type: field.type,
+        Name: field.name.encryptedString,
+        Value: field.value.encryptedString,
+      })
+    );
+  }
+
+  return encryptedFields;
+};

--- a/libs/cozy/fields.helper.ts
+++ b/libs/cozy/fields.helper.ts
@@ -64,6 +64,7 @@ export const buildFieldsFromPaper = (i18nService: any, paper: any): FieldView[] 
       formattedName = getTranslatedNameForContact({ lang });
       formattedValue = formatContactValue(paper.contacts.data);
     } else {
+      // do nothing if metadata qualification type is unknown (new type, wrong type, unknown type, ...)
       return;
     }
 

--- a/libs/cozy/note.helper.ts
+++ b/libs/cozy/note.helper.ts
@@ -12,12 +12,12 @@ import { buildFieldsFromPaper, copyEncryptedFields, buildField } from "./fields.
 
 interface NoteConversionOptions {
   client: CozyClient;
-  noteThumbnailUrl: string;
+  noteIllustrationUrl: string;
 }
 
 export const isNote = (document: any) => document.mime === "text/vnd.cozy.note+markdown";
 
-export const fetchNoteThumbnailUrl = async (client: CozyClient) => {
+export const fetchNoteIllustrationUrl = async (client: CozyClient) => {
   const { data: app } = await client.query(Q("io.cozy.apps").getById("notes"));
 
   const baseUrl = client.getStackClient().uri;
@@ -33,7 +33,7 @@ export const convertNoteToCipherResponse = async (
   paper: any,
   options: NoteConversionOptions
 ): Promise<CipherResponse> => {
-  const { client, noteThumbnailUrl } = options;
+  const { client, noteIllustrationUrl } = options;
 
   const cipherView = new CipherView();
   cipherView.id = paper.id;
@@ -44,7 +44,7 @@ export const convertNoteToCipherResponse = async (
   cipherView.paper.noteContent = await client
     .getStackClient()
     .fetchJSON("GET", "/notes/" + paper.id + "/text");
-  cipherView.paper.illustrationThumbnailUrl = noteThumbnailUrl;
+  cipherView.paper.illustrationThumbnailUrl = noteIllustrationUrl;
   cipherView.fields = buildFieldsFromPaper(i18nService, paper);
   cipherView.fields.push(buildField(i18nService.t("content"), cipherView.paper.noteContent));
 

--- a/libs/cozy/note.helper.ts
+++ b/libs/cozy/note.helper.ts
@@ -8,7 +8,7 @@ import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.r
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { PaperView } from "@bitwarden/common/vault/models/view/paper.view";
 
-import { buildFieldsFromPaper, copyEncryptedFields } from "./fields.helper";
+import { buildFieldsFromPaper, copyEncryptedFields, buildField } from "./fields.helper";
 
 interface NoteConversionOptions {
   client: CozyClient;
@@ -46,6 +46,7 @@ export const convertNoteToCipherResponse = async (
     .fetchJSON("GET", "/notes/" + paper.id + "/text");
   cipherView.paper.illustrationThumbnailUrl = noteThumbnailUrl;
   cipherView.fields = buildFieldsFromPaper(i18nService, paper);
+  cipherView.fields.push(buildField(i18nService.t("content"), cipherView.paper.noteContent));
 
   const cipherEncrypted = await cipherService.encrypt(cipherView);
   const cipherViewEncrypted = new CipherView(cipherEncrypted);

--- a/libs/cozy/note.helper.ts
+++ b/libs/cozy/note.helper.ts
@@ -45,6 +45,7 @@ export const convertNoteToCipherResponse = async (
     .getStackClient()
     .fetchJSON("GET", "/notes/" + paper.id + "/text");
   cipherView.paper.illustrationThumbnailUrl = noteIllustrationUrl;
+  cipherView.paper.illustrationUrl = noteIllustrationUrl;
   cipherView.fields = buildFieldsFromPaper(i18nService, paper);
   cipherView.fields.push(buildField(i18nService.t("content"), cipherView.paper.noteContent));
 
@@ -58,6 +59,7 @@ export const convertNoteToCipherResponse = async (
   cipherViewResponse.paper.type = cipherView.paper.type;
   cipherViewResponse.paper.noteContent = cipherView.paper.noteContent;
   cipherViewResponse.paper.illustrationThumbnailUrl = cipherView.paper.illustrationThumbnailUrl;
+  cipherViewResponse.paper.illustrationUrl = cipherView.paper.illustrationUrl;
   cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields);
 
   return cipherViewResponse;

--- a/libs/cozy/note.helper.ts
+++ b/libs/cozy/note.helper.ts
@@ -46,6 +46,7 @@ export const convertNoteToCipherResponse = async (
     .fetchJSON("GET", "/notes/" + paper.id + "/text");
   cipherView.paper.illustrationThumbnailUrl = noteIllustrationUrl;
   cipherView.paper.illustrationUrl = noteIllustrationUrl;
+  cipherView.paper.qualificationLabel = paper.metadata.qualification.label;
   cipherView.fields = buildFieldsFromPaper(i18nService, paper);
   cipherView.fields.push(buildField(i18nService.t("content"), cipherView.paper.noteContent));
 
@@ -60,6 +61,7 @@ export const convertNoteToCipherResponse = async (
   cipherViewResponse.paper.noteContent = cipherView.paper.noteContent;
   cipherViewResponse.paper.illustrationThumbnailUrl = cipherView.paper.illustrationThumbnailUrl;
   cipherViewResponse.paper.illustrationUrl = cipherView.paper.illustrationUrl;
+  cipherViewResponse.paper.qualificationLabel = cipherView.paper.qualificationLabel;
   cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields);
 
   return cipherViewResponse;

--- a/libs/cozy/note.helper.ts
+++ b/libs/cozy/note.helper.ts
@@ -8,6 +8,8 @@ import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.r
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { PaperView } from "@bitwarden/common/vault/models/view/paper.view";
 
+import { buildFieldsFromPaper, copyEncryptedFields } from "./fields.helper";
+
 interface NoteConversionOptions {
   client: CozyClient;
   noteThumbnailUrl: string;
@@ -27,6 +29,7 @@ export const fetchNoteThumbnailUrl = async (client: CozyClient) => {
 
 export const convertNoteToCipherResponse = async (
   cipherService: any,
+  i18nService: any,
   paper: any,
   options: NoteConversionOptions
 ): Promise<CipherResponse> => {
@@ -42,6 +45,7 @@ export const convertNoteToCipherResponse = async (
     .getStackClient()
     .fetchJSON("GET", "/notes/" + paper.id + "/text");
   cipherView.paper.illustrationThumbnailUrl = noteThumbnailUrl;
+  cipherView.fields = buildFieldsFromPaper(i18nService, paper);
 
   const cipherEncrypted = await cipherService.encrypt(cipherView);
   const cipherViewEncrypted = new CipherView(cipherEncrypted);
@@ -53,6 +57,7 @@ export const convertNoteToCipherResponse = async (
   cipherViewResponse.paper.type = cipherView.paper.type;
   cipherViewResponse.paper.noteContent = cipherView.paper.noteContent;
   cipherViewResponse.paper.illustrationThumbnailUrl = cipherView.paper.illustrationThumbnailUrl;
+  cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields);
 
   return cipherViewResponse;
 };

--- a/libs/cozy/paper.helper.ts
+++ b/libs/cozy/paper.helper.ts
@@ -29,6 +29,12 @@ const buildIllustrationThumbnailUrl = (paper: any, baseUrl: string) => {
   return paper.links.tiny ? new URL(paper.links.tiny, baseUrl).toString() : DEFAULT_THUMBNAIL_URL;
 };
 
+const buildIllustrationUrl = (paper: any, baseUrl: string) => {
+  return paper.links.medium
+    ? new URL(paper.links.medium, baseUrl).toString()
+    : DEFAULT_THUMBNAIL_URL;
+};
+
 export const convertPaperToCipherResponse = async (
   cipherService: any,
   i18nService: any,
@@ -45,6 +51,7 @@ export const convertPaperToCipherResponse = async (
   cipherView.paper.type = PaperType.Paper;
   cipherView.paper.ownerName = buildOwnerName(i18nService, paper);
   cipherView.paper.illustrationThumbnailUrl = buildIllustrationThumbnailUrl(paper, baseUrl);
+  cipherView.paper.illustrationUrl = buildIllustrationUrl(paper, baseUrl);
   cipherView.fields = buildFieldsFromPaper(i18nService, paper);
 
   const cipherEncrypted = await cipherService.encrypt(cipherView);
@@ -57,6 +64,7 @@ export const convertPaperToCipherResponse = async (
   cipherViewResponse.paper.type = cipherView.paper.type;
   cipherViewResponse.paper.ownerName = cipherView.paper.ownerName;
   cipherViewResponse.paper.illustrationThumbnailUrl = cipherView.paper.illustrationThumbnailUrl;
+  cipherViewResponse.paper.illustrationUrl = cipherView.paper.illustrationUrl;
   cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields);
 
   return cipherViewResponse;

--- a/libs/cozy/paper.helper.ts
+++ b/libs/cozy/paper.helper.ts
@@ -5,6 +5,8 @@ import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.r
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { PaperView } from "@bitwarden/common/vault/models/view/paper.view";
 
+import { buildFieldsFromPaper, copyEncryptedFields } from "./fields.helper";
+
 interface PaperConversionOptions {
   baseUrl: string;
 }
@@ -43,6 +45,7 @@ export const convertPaperToCipherResponse = async (
   cipherView.paper.type = PaperType.Paper;
   cipherView.paper.ownerName = buildOwnerName(i18nService, paper);
   cipherView.paper.illustrationThumbnailUrl = buildIllustrationThumbnailUrl(paper, baseUrl);
+  cipherView.fields = buildFieldsFromPaper(i18nService, paper);
 
   const cipherEncrypted = await cipherService.encrypt(cipherView);
   const cipherViewEncrypted = new CipherView(cipherEncrypted);
@@ -54,6 +57,7 @@ export const convertPaperToCipherResponse = async (
   cipherViewResponse.paper.type = cipherView.paper.type;
   cipherViewResponse.paper.ownerName = cipherView.paper.ownerName;
   cipherViewResponse.paper.illustrationThumbnailUrl = cipherView.paper.illustrationThumbnailUrl;
+  cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields);
 
   return cipherViewResponse;
 };

--- a/libs/cozy/paper.helper.ts
+++ b/libs/cozy/paper.helper.ts
@@ -52,6 +52,7 @@ export const convertPaperToCipherResponse = async (
   cipherView.paper.ownerName = buildOwnerName(i18nService, paper);
   cipherView.paper.illustrationThumbnailUrl = buildIllustrationThumbnailUrl(paper, baseUrl);
   cipherView.paper.illustrationUrl = buildIllustrationUrl(paper, baseUrl);
+  cipherView.paper.qualificationLabel = paper.metadata.qualification.label;
   cipherView.fields = buildFieldsFromPaper(i18nService, paper);
 
   const cipherEncrypted = await cipherService.encrypt(cipherView);
@@ -65,6 +66,7 @@ export const convertPaperToCipherResponse = async (
   cipherViewResponse.paper.ownerName = cipherView.paper.ownerName;
   cipherViewResponse.paper.illustrationThumbnailUrl = cipherView.paper.illustrationThumbnailUrl;
   cipherViewResponse.paper.illustrationUrl = cipherView.paper.illustrationUrl;
+  cipherViewResponse.paper.qualificationLabel = cipherView.paper.qualificationLabel;
   cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields);
 
   return cipherViewResponse;

--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -5,7 +5,7 @@ import CozyClient from "cozy-client/types/CozyClient";
 
 import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.response";
 
-import { convertNoteToCipherResponse, isNote, fetchNoteThumbnailUrl } from "./note.helper";
+import { convertNoteToCipherResponse, isNote, fetchNoteIllustrationUrl } from "./note.helper";
 import { convertPaperToCipherResponse } from "./paper.helper";
 
 const fetchPapers = async (client: CozyClient) => {
@@ -81,14 +81,14 @@ const convertPapersAsCiphers = async (
 
   const papersCiphers = [];
 
-  const noteThumbnailUrl = await fetchNoteThumbnailUrl(client);
+  const noteIllustrationUrl = await fetchNoteIllustrationUrl(client);
 
   for (const paper of papers) {
     let cipherResponse: CipherResponse;
     if (isNote(paper)) {
       cipherResponse = await convertNoteToCipherResponse(cipherService, i18nService, paper, {
         client,
-        noteThumbnailUrl,
+        noteIllustrationUrl,
       });
     } else {
       cipherResponse = await convertPaperToCipherResponse(cipherService, i18nService, paper, {

--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -33,6 +33,11 @@ export const buildFilesQueryWithQualificationLabel = () => {
     "metadata.contractType",
     "metadata.refTaxIncome",
     "metadata.title",
+    "metadata.AObtentionDate",
+    "metadata.BObtentionDate",
+    "metadata.CObtentionDate",
+    "metadata.DObtentionDate",
+    "metadata.page",
     "metadata.version",
     "cozyMetadata.createdByApp",
     "cozyMetadata.sourceAccountIdentifier",
@@ -81,7 +86,7 @@ const convertPapersAsCiphers = async (
   for (const paper of papers) {
     let cipherResponse: CipherResponse;
     if (isNote(paper)) {
-      cipherResponse = await convertNoteToCipherResponse(cipherService, paper, {
+      cipherResponse = await convertNoteToCipherResponse(cipherService, i18nService, paper, {
         client,
         noteThumbnailUrl,
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "chalk": "^4.1.0",
         "commander": "^7.2.0",
         "core-js": "^3.11.0",
-        "cozy-client": "45.13.0",
+        "cozy-client": "45.15.0",
         "cozy-device-helper": ">1.12.0",
         "cozy-flags": ">2.8.6",
         "cozy-logger": ">1.7.0",
@@ -20584,9 +20584,9 @@
       }
     },
     "node_modules/cozy-client": {
-      "version": "45.13.0",
-      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-45.13.0.tgz",
-      "integrity": "sha512-bftRIKkjfdjGtWGguvhuuohWElUSN9q/x+u6ksCx6iiM7VWpPBIJEMqfj+tA+RkghJnN80Phdguk3HMkENxqEA==",
+      "version": "45.15.0",
+      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-45.15.0.tgz",
+      "integrity": "sha512-/137/DInGvMTitlhqLrtKXa+7Co2dnlbvu1jRwZ9+qaFbKZ1NMCPYi5mBWVcRy2HHqB++ph9HrjXEORVVky0/g==",
       "dependencies": {
         "@cozy/minilog": "1.0.0",
         "@types/jest": "^26.0.20",
@@ -63779,9 +63779,9 @@
       }
     },
     "cozy-client": {
-      "version": "45.13.0",
-      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-45.13.0.tgz",
-      "integrity": "sha512-bftRIKkjfdjGtWGguvhuuohWElUSN9q/x+u6ksCx6iiM7VWpPBIJEMqfj+tA+RkghJnN80Phdguk3HMkENxqEA==",
+      "version": "45.15.0",
+      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-45.15.0.tgz",
+      "integrity": "sha512-/137/DInGvMTitlhqLrtKXa+7Co2dnlbvu1jRwZ9+qaFbKZ1NMCPYi5mBWVcRy2HHqB++ph9HrjXEORVVky0/g==",
       "requires": {
         "@cozy/minilog": "1.0.0",
         "@types/jest": "^26.0.20",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "chalk": "^4.1.0",
     "commander": "^7.2.0",
     "core-js": "^3.11.0",
-    "cozy-client": "45.13.0",
+    "cozy-client": "45.15.0",
     "cozy-ui": "51.3.1",
     "@cozy/minilog": "1.0.0",
     "cozy-device-helper": ">1.12.0",


### PR DESCRIPTION
Display notes and papers, in other words for notes and papers in the cipher `View`:
- add paper thumbnail (exemple in the screenshot is a screenshot itself)
- display paper metadata as `Fields`
- modify "Edit" and "Open in Cozy" links to redirect to mespapiers or notes app
- hide share action
- hide clone action
- add print action
- add download action
- UI and wording updates

![image](https://github.com/cozy/cozy-keys-browser/assets/10849491/25daa5cd-21f3-4b9b-90d8-d991b089682e)
