### PR TITLE
feat: Add new theme `LightContrasted` and apply it when necessary

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -775,6 +775,10 @@
     "message": "Light",
     "description": "Light color"
   },
+  "lightContrasted": {
+    "message": "Light with pronounced contrast",
+    "description": "Light color"
+  },
   "solarizedDark": {
     "message": "Solarized dark",
     "description": "'Solarized' is a noun and the name of a color scheme. It should not be translated."

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -778,6 +778,10 @@
     "message": "Clair",
     "description": "Light color"
   },
+  "lightContrasted": {
+    "message": "Clair avec contraste accentué",
+    "description": "Light color"
+  },
   "solarizedDark": {
     "message": "Solarized Dark",
     "description": "'Solarized' is a noun and the name of a color scheme. It should not be translated."

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -134,6 +134,7 @@ import { MessagingService as MessagingServiceAbstraction } from "../services/abs
 import { SyncService } from "../popup/services/sync.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { UriMatchType } from "@bitwarden/common/enums/uriMatchType";
+import { ThemeType } from "@bitwarden/common/enums/themeType";
 /* eslint-enable */
 /* end Cozy imports */
 
@@ -819,6 +820,14 @@ export default class MainBackground {
 
   async logout(expired: boolean, userId?: string) {
     await this.eventUploadService.uploadEvents(userId);
+
+    // Cozy customization, reset theme to LighContrasted if user did not manually changed it
+    //*
+    const isUserSetTheme = await this.stateService.getIsUserSetTheme();
+    if (!isUserSetTheme) {
+      await this.stateService.setTheme(ThemeType.LightContrasted);
+    }
+    //*/
 
     await Promise.all([
       this.syncService.setLastSync(new Date(0), userId),

--- a/apps/browser/src/popup/scss/base.scss
+++ b/apps/browser/src/popup/scss/base.scss
@@ -321,6 +321,9 @@ header {
       padding: 0 6px;
       background-color: white;
       color: $brand-primary;
+      @include themify($themes) {
+        color: themed("primaryColor");
+      }
       border-radius: 4px;
       white-space: nowrap;
       overflow: hidden;
@@ -346,6 +349,9 @@ header {
       #search-tag-text::after {
         content: "";
         border-bottom: 1px solid $brand-primary;
+        @include themify($themes) {
+          border-bottom-color: themed("primaryColor");
+        }
         position: absolute;
         left: 0;
         top: 56%;
@@ -354,6 +360,10 @@ header {
       #search-tag-text + span {
         color: $brand-primary;
         border-color: $brand-primary;
+        @include themify($themes) {
+          color: themed("primaryColor");
+          border-color: themed("primaryColor");
+        }
       }
     }
 
@@ -458,11 +468,15 @@ header {
         text-overflow: ellipsis;
         color: $text-muted;
         width: 100%;
+        @include themify($themes) {
+          color: themed("mutedColor");
+        }
 
         &:hover,
         &:focus {
           @include themify($themes) {
             background-color: themed("tabBackgroundHoverColor");
+            color: themed("primaryColor");
           }
         }
 
@@ -475,6 +489,9 @@ header {
 
       &.active * {
         color: $brand-primary;
+        @include themify($themes) {
+          color: themed("primaryColor"); //used to keep tab colored when active
+        }
         a,
         button {
           @include themify($themes) {
@@ -484,6 +501,9 @@ header {
         // Cozy customization; active color for font icons transformed in SVG icons (see .tab-icon-cozy)
         .bwi {
           background-color: $brand-primary;
+          @include themify($themes) {
+            background-color: themed("primaryColor"); //used to keep tab colored when active
+          }
         }
         // Cozy customization end
       }

--- a/apps/browser/src/popup/scss/box.scss
+++ b/apps/browser/src/popup/scss/box.scss
@@ -835,6 +835,9 @@
       justify-content: center;
       white-space: nowrap;
       background-color: $brand-primary;
+      @include themify($themes) {
+        background-color: themed("primaryColor");
+      }
     }
   }
 

--- a/apps/browser/src/popup/scss/buttons.scss
+++ b/apps/browser/src/popup/scss/buttons.scss
@@ -17,7 +17,7 @@
 
   &.primary {
     @include themify($themes) {
-      background-color: $button-background-color-primary;
+      background-color: themed("buttonBackgroundColorPrimary");
       color: themed("buttonPrimaryColor");
     }
   }
@@ -44,7 +44,7 @@
 
     &.primary {
       @include themify($themes) {
-        background-color: $button-background-color-primary-active;
+        background-color: themed("buttonBackgroundColorPrimaryActive");
         color: themed("buttonPrimaryColor");
       }
     }
@@ -67,7 +67,7 @@
 
     &.primary {
       @include themify($themes) {
-        background-color: $button-background-color-primary-active;
+        background-color: themed("buttonBackgroundColorPrimaryActive");
         color: themed("buttonPrimaryColor");
       }
     }
@@ -89,6 +89,9 @@
     border: none !important;
     background: none !important;
     color: $brand-primary !important;
+    @include themify($themes) {
+      color: themed("primaryColor") !important;
+    }
     font-size: 12px;
     font-weight: bold;
     &:hover {

--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -306,9 +306,15 @@ This class is responsible of changing tabs colors :
   &:active,
   &.active {
     color: $brand-primary;
+    @include themify($themes) {
+      color: themed("primaryColor");
+    }
 
     .bwi {
       background-color: $brand-primary;
+      @include themify($themes) {
+        background-color: themed("primaryColor");
+      }
     }
   }
 }
@@ -380,10 +386,16 @@ This class is responsible of changing tabs colors :
 
 li.active .icon-cozy-inline > svg {
   fill: $brand-primary;
+  @include themify($themes) {
+    fill: themed("primaryColor");
+  }
 }
 
 .text-primary .icon-cozy-inline > svg {
   fill: $brand-primary;
+  @include themify($themes) {
+    fill: themed("primaryColor");
+  }
 }
 
 // .icon.text-primary .icon-cozy {
@@ -588,6 +600,9 @@ li.active .icon-cozy-inline > svg {
   mask-size: contain;
   -webkit-mask-size: contain;
   background-color: $brand-primary;
+  @include themify($themes) {
+    background-color: themed("primaryColor");
+  }
 }
 
 .icon-download-paper {
@@ -598,6 +613,9 @@ li.active .icon-cozy-inline > svg {
   mask-size: contain;
   -webkit-mask-size: contain;
   background-color: $brand-primary;
+  @include themify($themes) {
+    background-color: themed("primaryColor");
+  }
 }
 
 .icon-profile {

--- a/apps/browser/src/popup/scss/variables.scss
+++ b/apps/browser/src/popup/scss/variables.scss
@@ -1,5 +1,8 @@
 @import "~nord/src/sass/nord.scss";
 
+// Cozy utility colors
+$grey900: #1d212a;
+
 $dark-icon-themes: "theme_dark", "theme_solarizedDark", "theme_nord";
 
 $font-family-sans-serif: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -9,7 +12,8 @@ $font-size-large: 16px;
 $font-size-xlarge: 22px;
 $font-size-xxlarge: 28px;
 $font-size-small: 12px;
-$text-color: #000000;
+// Close to cozy-ui text primary
+$text-color: rgba($grey900, 0.9);
 $border-color: #f0f0f0;
 $border-color-dark: #ddd;
 $list-item-hover: #fbfbfb;
@@ -24,15 +28,16 @@ $charcoal-grey: #32363f;
 $gray: #5d6165;
 $gray-light: #95999d;
 $gray-silver: #d6d8da;
-$text-muted: $gray-light;
+// Close to cozy-ui text secondary
+$text-muted: rgba($grey900, 0.48);
 
 $brand-primary: #297ef2;
-$brand-primary-active: #0057d9;
-$brand-danger: #dd4b39;
-$brand-success: #00a65a;
-$brand-info: #555555;
-$brand-warning: #bf7e16;
-$brand-primary-accent: #1252a3;
+$brand-primary-active: darken($brand-primary, 5%);
+$brand-danger: #ea3f3f;
+$brand-success: #09ae1c;
+$brand-info: #009fa2;
+$brand-warning: #cb8100;
+$brand-primary-accent: darken($brand-primary, 8%);
 
 $background-color: #f5f6f7;
 $background-color-alt: #ffffff;
@@ -90,8 +95,8 @@ $themes: (
     headerBackgroundColor: $brand-primary,
     headerBackgroundHoverColor: rgba(255, 255, 255, 0.1),
     headerBorderColor: $brand-primary,
-    headerInputBackgroundColor: darken($brand-primary, 8%),
-    headerInputBackgroundFocusColor: darken($brand-primary, 10%),
+    headerInputBackgroundColor: lighten($brand-primary, 8%),
+    headerInputBackgroundFocusColor: lighten($brand-primary, 8%),
     headerInputColor: #ffffff,
     headerInputPlaceholderColor: lighten($brand-primary, 35%),
     listItemBackgroundHoverColor: $list-item-hover,

--- a/apps/browser/src/popup/scss/variables.scss
+++ b/apps/browser/src/popup/scss/variables.scss
@@ -14,6 +14,7 @@ $font-size-xxlarge: 28px;
 $font-size-small: 12px;
 // Close to cozy-ui text primary
 $text-color: rgba($grey900, 0.9);
+$text-color-contrasted: rgba($grey900, 0.9);
 $border-color: #f0f0f0;
 $border-color-dark: #ddd;
 $list-item-hover: #fbfbfb;
@@ -30,6 +31,7 @@ $gray-light: #95999d;
 $gray-silver: #d6d8da;
 // Close to cozy-ui text secondary
 $text-muted: rgba($grey900, 0.48);
+$text-muted-contrasted: rgba($grey900, 0.72);
 
 $brand-primary: #297ef2;
 $brand-primary-active: darken($brand-primary, 5%);
@@ -38,6 +40,14 @@ $brand-success: #09ae1c;
 $brand-info: #009fa2;
 $brand-warning: #cb8100;
 $brand-primary-accent: darken($brand-primary, 8%);
+
+$brand-primary-contrasted: #0e6ff6;
+$brand-primary-active-contrasted: darken($brand-primary-contrasted, 5%);
+$brand-danger-contrasted: #e81111;
+$brand-success-contrasted: #068915;
+$brand-info-contrasted: #008281;
+$brand-warning-contrasted: #a36800;
+$brand-primary-accent-contrasted: darken($brand-primary-contrasted, 8%);
 
 $background-color: #f5f6f7;
 $background-color-alt: #ffffff;
@@ -122,6 +132,69 @@ $themes: (
     successColor: $brand-success,
     infoColor: $brand-info,
     warningColor: $brand-warning,
+    logoSuffix: "dark",
+    passwordNumberColor: #007fde,
+    passwordSpecialColor: #c40800,
+    passwordCountText: #212529,
+    calloutBorderColor: $border-color-dark,
+    calloutBackgroundColor: $box-background-color,
+    toastTextColor: #ffffff,
+    svgSuffix: "-light.svg",
+    transparentColor: rgba(0, 0, 0, 0),
+    dateInputColorScheme: light,
+    // https://stackoverflow.com/a/53336754
+    webkitCalendarPickerFilter: invert(46%) sepia(69%) saturate(6397%) hue-rotate(211deg)
+      brightness(85%) contrast(103%),
+    // light has no hover so use same color
+    webkitCalendarPickerHoverFilter: invert(46%) sepia(69%) saturate(6397%) hue-rotate(211deg)
+      brightness(85%) contrast(103%),
+    codeColor: #e83e8c,
+  ),
+  lightContrasted: (
+    textColor: $text-color-contrasted,
+    hoverColorTransparent: rgba($text-color-contrasted, 0.15),
+    borderColor: $border-color-dark,
+    backgroundColor: $background-color,
+    borderColorAlt: $border-color-alt,
+    backgroundColorAlt: #ffffff,
+    scrollbarColor: rgba(100, 100, 100, 0.2),
+    scrollbarHoverColor: rgba(100, 100, 100, 0.4),
+    boxBackgroundColor: $box-background-color,
+    boxBackgroundHoverColor: $box-background-hover-color,
+    boxBorderColor: $box-border-color,
+    tabBackgroundColor: #ffffff,
+    tabBackgroundHoverColor: $list-item-hover,
+    headerColor: #ffffff,
+    headerBackgroundColor: $brand-primary-contrasted,
+    headerBackgroundHoverColor: rgba(255, 255, 255, 0.1),
+    headerBorderColor: $brand-primary-contrasted,
+    headerInputBackgroundColor: lighten($brand-primary-contrasted, 8%),
+    headerInputBackgroundFocusColor: lighten($brand-primary-contrasted, 8%),
+    headerInputColor: #ffffff,
+    headerInputPlaceholderColor: lighten($brand-primary-contrasted, 35%),
+    listItemBackgroundHoverColor: $list-item-hover,
+    disabledIconColor: $list-icon-color,
+    disabledBoxOpacity: $disabled-box-opacity,
+    headingColor: $charcoal-grey,
+    labelColor: $gray-light,
+    mutedColor: $text-muted-contrasted,
+    totpStrokeColor: $brand-primary-contrasted,
+    boxRowButtonColor: $brand-primary-contrasted,
+    boxRowButtonHoverColor: darken($brand-primary-contrasted, 10%),
+    inputBorderColor: darken($border-color-dark, 7%),
+    inputBackgroundColor: #ffffff,
+    inputPlaceholderColor: lighten($gray-light, 20%),
+    buttonBackgroundColor: $button-background-color,
+    buttonBorderColor: $button-border-color,
+    buttonColor: $button-color,
+    buttonPrimaryColor: $button-color-primary,
+    buttonDangerColor: $button-color-danger,
+    primaryColor: $brand-primary-contrasted,
+    primaryAccentColor: $brand-primary-accent-contrasted,
+    dangerColor: $brand-danger-contrasted,
+    successColor: $brand-success-contrasted,
+    infoColor: $brand-info-contrasted,
+    warningColor: $brand-warning-contrasted,
     logoSuffix: "dark",
     passwordNumberColor: #007fde,
     passwordSpecialColor: #c40800,

--- a/apps/browser/src/popup/scss/variables.scss
+++ b/apps/browser/src/popup/scss/variables.scss
@@ -65,6 +65,8 @@ $button-border-color: darken($border-color-dark, 12%);
 $button-background-color: white;
 $button-background-color-primary: $brand-primary;
 $button-background-color-primary-active: $brand-primary-active;
+$button-background-color-primary-contrasted: $brand-primary-contrasted;
+$button-background-color-primary-active-contrasted: $brand-primary-active-contrasted;
 $button-color: lighten($text-color, 40%);
 $button-color-primary: #ffffff;
 $button-color-danger: darken($brand-danger, 10%);
@@ -122,6 +124,8 @@ $themes: (
     inputBackgroundColor: #ffffff,
     inputPlaceholderColor: lighten($gray-light, 20%),
     buttonBackgroundColor: $button-background-color,
+    buttonBackgroundColorPrimary: $button-background-color-primary,
+    buttonBackgroundColorPrimaryActive: $button-background-color-primary-active,
     buttonBorderColor: $button-border-color,
     buttonColor: $button-color,
     buttonPrimaryColor: $button-color-primary,
@@ -185,6 +189,8 @@ $themes: (
     inputBackgroundColor: #ffffff,
     inputPlaceholderColor: lighten($gray-light, 20%),
     buttonBackgroundColor: $button-background-color,
+    buttonBackgroundColorPrimary: $button-background-color-primary-contrasted,
+    buttonBackgroundColorPrimaryActive: $button-background-color-primary-active-contrasted,
     buttonBorderColor: $button-border-color,
     buttonColor: $button-color,
     buttonPrimaryColor: $button-color-primary,

--- a/apps/browser/src/popup/services/cozyClient.service.ts
+++ b/apps/browser/src/popup/services/cozyClient.service.ts
@@ -81,6 +81,11 @@ export class CozyClientService {
     this.messagingService.send("flagChange", { flagName, flagValue });
   }
 
+  async getFlagValue(flagName: string) {
+    await this.getClientInstance();
+    return flag(flagName);
+  }
+
   async getClientInstance() {
     if (this.instance) {
       const token = await this.apiService.getActiveBearerToken();

--- a/apps/browser/src/popup/services/cozyClient.service.ts
+++ b/apps/browser/src/popup/services/cozyClient.service.ts
@@ -118,6 +118,7 @@ export class CozyClientService {
     });
     this.instance.registerPlugin(flag.plugin, undefined);
     this.registerFlags();
+    await this.instance.plugins.flags.initializing;
     await this.getSubDomainType();
     return this.instance;
   }

--- a/apps/browser/src/popup/settings/options.component.ts
+++ b/apps/browser/src/popup/settings/options.component.ts
@@ -54,6 +54,7 @@ export class OptionsComponent implements OnInit {
     this.themeOptions = [
       { name: i18nService.t("default"), value: ThemeType.System },
       { name: i18nService.t("light"), value: ThemeType.Light },
+      { name: i18nService.t("lightContrasted"), value: ThemeType.LightContrasted },
       { name: i18nService.t("dark"), value: ThemeType.Dark },
       { name: "Nord", value: ThemeType.Nord },
       { name: i18nService.t("solarizedDark"), value: ThemeType.SolarizedDark },

--- a/apps/browser/src/popup/settings/options.component.ts
+++ b/apps/browser/src/popup/settings/options.component.ts
@@ -180,6 +180,7 @@ export class OptionsComponent implements OnInit {
 
   async saveTheme() {
     await this.themingService.updateConfiguredTheme(this.theme);
+    await this.stateService.setIsUserSetTheme(true);
   }
 
   async saveDefaultUriMatch() {

--- a/libs/angular/src/services/theming/theming.service.ts
+++ b/libs/angular/src/services/theming/theming.service.ts
@@ -45,6 +45,7 @@ export class ThemingService implements AbstractThemingService {
     this.theme$.subscribe((theme: Theme) => {
       this.document.documentElement.classList.remove(
         "theme_" + ThemeType.Light,
+        "theme_" + ThemeType.LightContrasted,
         "theme_" + ThemeType.Dark,
         "theme_" + ThemeType.Nord,
         "theme_" + ThemeType.SolarizedDark

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -332,6 +332,11 @@ export abstract class StateService<T extends Account = Account> {
   setSsoState: (value: string, options?: StorageOptions) => Promise<void>;
   getTheme: (options?: StorageOptions) => Promise<ThemeType>;
   setTheme: (value: ThemeType, options?: StorageOptions) => Promise<void>;
+  // Cozy customization, track if user manually set a preferred theme
+  //*
+  getIsUserSetTheme: (options?: StorageOptions) => Promise<boolean>;
+  setIsUserSetTheme: (value: boolean, options?: StorageOptions) => Promise<void>;
+  //*/
   getTwoFactorToken: (options?: StorageOptions) => Promise<string>;
   setTwoFactorToken: (value: string, options?: StorageOptions) => Promise<void>;
   getUserId: (options?: StorageOptions) => Promise<string>;

--- a/libs/common/src/enums/themeType.ts
+++ b/libs/common/src/enums/themeType.ts
@@ -1,6 +1,7 @@
 export enum ThemeType {
   System = "system",
   Light = "light",
+  LightContrasted = "lightContrasted",
   Dark = "dark",
   Nord = "nord",
   SolarizedDark = "solarizedDark",

--- a/libs/common/src/models/domain/global-state.ts
+++ b/libs/common/src/models/domain/global-state.ts
@@ -19,6 +19,12 @@ export class GlobalState {
   /*/
   theme?: ThemeType = ThemeType.LightContrasted;
   //*/
+
+  // Cozy customization, track if user manually set a preferred theme
+  //*
+  isUserSetTheme = false;
+  //*/
+
   window?: WindowState = new WindowState();
   twoFactorToken?: string;
   disableFavicon?: boolean;

--- a/libs/common/src/models/domain/global-state.ts
+++ b/libs/common/src/models/domain/global-state.ts
@@ -13,7 +13,12 @@ export class GlobalState {
   ssoOrganizationIdentifier?: string;
   ssoState?: string;
   rememberedEmail?: string;
+  // Cozy customization, set `LightContrasted` theme by default on first opening
+  /*
   theme?: ThemeType = ThemeType.System;
+  /*/
+  theme?: ThemeType = ThemeType.LightContrasted;
+  //*/
   window?: WindowState = new WindowState();
   twoFactorToken?: string;
   disableFavicon?: boolean;

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -2206,6 +2206,26 @@ export class StateService<
     );
   }
 
+  // Cozy customization, track if user manually set a preferred theme
+  //*
+  async getIsUserSetTheme(options?: StorageOptions): Promise<boolean> {
+    return (
+      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
+    )?.isUserSetTheme;
+  }
+
+  async setIsUserSetTheme(value: boolean, options?: StorageOptions): Promise<void> {
+    const globals = await this.getGlobals(
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+    globals.isUserSetTheme = value;
+    await this.saveGlobals(
+      globals,
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+  }
+  //*/
+
   async getTwoFactorToken(options?: StorageOptions): Promise<string> {
     return (
       await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))


### PR DESCRIPTION
When the user log in a Cozy instance, we want to apply the correct
theme based on the instance configuration but also on the user's
preferences

The instance configuration is defined by the
`passwords.theme.default-contrasted`. If this flag is true, then the
default theme should be the `LightContrasted` one. Otherwise the
`System` theme should be applied

The user's preferences are defined when the user changes the app theme
from the settings page. From that point we want to keep the selected
theme even when the user logs out

If the user did not change the app theme from the settings page, then a
log out should revert to the `LightContrasted` theme, which is the
app's default theme

Note that if the instance's flag is true, then we want to enforce the
`LightContrasted` whatever if the user did set a different theme or not
in their previous session

___

This PR also update the `Light` theme latest Cozy's latest color palettes