### PR TITLE
Favorite and expiration annotation

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1794,6 +1794,9 @@
   "expired": {
     "message": "Expired"
   },
+  "expiredIn": {
+    "message": "Expire in"
+  },
   "pendingDeletion": {
     "message": "Pending deletion"
   },

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -1842,6 +1842,9 @@
   "expired": {
     "message": "Expiré"
   },
+  "expiredIn": {
+    "message": "Expire dans"
+  },
   "pendingDeletion": {
     "message": "En attente de suppression"
   },

--- a/apps/browser/src/popup/app.module.ts
+++ b/apps/browser/src/popup/app.module.ts
@@ -48,6 +48,7 @@ import { VaultFilterComponent } from "../vault/popup/components/vault/vault-filt
 import { VaultItemsComponent } from "../vault/popup/components/vault/vault-items.component";
 import { VaultSelectComponent } from "../vault/popup/components/vault/vault-select.component";
 import { ViewCustomFieldsComponent } from "../vault/popup/components/vault/view-custom-fields.component";
+import { ViewExpirationDateComponent } from "../vault/popup/components/vault/view-expiration-date.component";
 import { ViewComponent } from "../vault/popup/components/vault/view.component";
 
 import { AppRoutingModule } from "./app-routing.module";
@@ -157,6 +158,7 @@ import { AddGenericComponent } from "../cozy/components/add-generic/add-generic.
     VaultTimeoutInputComponent,
     ViewComponent,
     ViewCustomFieldsComponent,
+    ViewExpirationDateComponent,
     RemovePasswordComponent,
     VaultSelectComponent,
     AboutComponent,

--- a/apps/browser/src/vault/popup/components/vault/view-custom-fields.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view-custom-fields.component.html
@@ -26,6 +26,10 @@
         <span *ngIf="field.type === fieldType.Linked" class="row-label">{{ field.name }}</span>
         <div *ngIf="field.type === fieldType.Text">
           {{ field.value || "&nbsp;" }}
+          <app-vault-view-expiration-date
+            *ngIf="field.subtype === fieldSubType.ExpirationDate"
+            [field]="field"
+          ></app-vault-view-expiration-date>
         </div>
         <div *ngIf="field.type === fieldType.Hidden">
           <span *ngIf="!field.showValue" class="monospaced">{{ field.maskedValue }}</span>

--- a/apps/browser/src/vault/popup/components/vault/view-expiration-date.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view-expiration-date.component.html
@@ -1,0 +1,7 @@
+·
+<span *ngIf="field.expirationData.isExpired" class="text-danger">
+  {{ "expired" | i18n }}
+</span>
+<span *ngIf="field.expirationData.isExpiringSoon" class="text-warning">
+  {{ "expiredIn" | i18n }} {{ getExpirationDistance() }}
+</span>

--- a/apps/browser/src/vault/popup/components/vault/view-expiration-date.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view-expiration-date.component.ts
@@ -1,0 +1,25 @@
+/* eslint-disable import/no-duplicates */
+import { Component, Input } from "@angular/core";
+import formatDistanceToNowStrict from "date-fns/formatDistanceToNowStrict";
+import fr from "date-fns/locale/fr";
+
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
+
+@Component({
+  selector: "app-vault-view-expiration-date",
+  templateUrl: "./view-expiration-date.component.html",
+})
+export class ViewExpirationDateComponent {
+  @Input() field: FieldView;
+
+  constructor(private i18nService: I18nService) {}
+
+  getExpirationDistance(): string {
+    return formatDistanceToNowStrict(
+      new Date(this.field.expirationData.expirationDate),
+      // @ts-expect-error I did not succeed in getting i18nService.translationLocale so I fallback to a private property
+      { locale: this.i18nService.systemLanguage === "fr" ? fr : undefined }
+    );
+  }
+}

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -702,6 +702,29 @@
           <span>{{ "changeFolder" | i18n }}</span>
         </div>
       </button>
+      <!-- Cozy customization; new favorite button -->
+      <button
+        type="button"
+        class="box-content-row"
+        appStopClick
+        appBlurClick
+        (click)="favorite()"
+        *ngIf="cipher.type === cipherType.Paper"
+      >
+        <div *ngIf="cipher.favorite" class="row-main text-primary">
+          <div class="icon text-primary" aria-hidden="true">
+            <i class="bwi bwi-star-f bwi-lg bwi-fw"></i>
+          </div>
+          <span>{{ "unfavorite" | i18n }}</span>
+        </div>
+        <div *ngIf="!cipher.favorite" class="row-main text-primary">
+          <div class="icon text-primary" aria-hidden="true">
+            <i class="bwi bwi-star bwi-lg bwi-fw"></i>
+          </div>
+          <span>{{ "favorite" | i18n }}</span>
+        </div>
+      </button>
+      <!-- Cozy customization end -->
       <!-- Cozy customization -->
       <button
         type="button"

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -37,7 +37,7 @@ const BroadcasterSubscriptionId = "ChildViewComponent";
 /* start Cozy imports */
 /* eslint-disable */
 import { deleteCipher } from "./cozy-utils";
-import { deletePaperCipher } from "../../../../../../../libs/cozy/paperCipher";
+import { favoritePaperCipher, deletePaperCipher } from "../../../../../../../libs/cozy/paperCipher";
 import { CozyClientService } from "../../../../popup/services/cozyClient.service";
 import { CAN_SHARE_ORGANIZATION } from "../../../../cozy/flags";
 import { HistoryService } from "../../../../popup/services/history.service";
@@ -214,6 +214,23 @@ export class ViewComponent extends BaseViewComponent {
       },
     });
     return true;
+  }
+
+  async favorite() {
+    try {
+      await favoritePaperCipher(
+        this.cipherService,
+        this.i18nService,
+        this.cipher,
+        this.cozyClientService
+      );
+
+      const cipher = await this.cipherService.get(this.cipherId);
+
+      this.cipher = await cipher.decrypt();
+    } catch {
+      this.platformUtilsService.showToast("error", null, this.i18nService.t("unexpectedError"));
+    }
   }
 
   async share() {

--- a/libs/angular/src/vault/components/view-custom-fields.component.ts
+++ b/libs/angular/src/vault/components/view-custom-fields.component.ts
@@ -2,6 +2,7 @@ import { Directive, Input } from "@angular/core";
 
 import { EventCollectionService } from "@bitwarden/common/abstractions/event/event-collection.service";
 import { EventType } from "@bitwarden/common/enums/eventType";
+import { FieldSubType } from "@bitwarden/common/enums/fieldSubType";
 import { FieldType } from "@bitwarden/common/enums/fieldType";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
@@ -13,6 +14,9 @@ export class ViewCustomFieldsComponent {
   @Input() copy: (value: string, typeI18nKey: string, aType: string) => void;
 
   fieldType = FieldType;
+  // Cozy customization
+  fieldSubType = FieldSubType;
+  // Cozy customization end
 
   constructor(private eventCollectionService: EventCollectionService) {}
 

--- a/libs/common/src/enums/fieldSubType.ts
+++ b/libs/common/src/enums/fieldSubType.ts
@@ -1,0 +1,6 @@
+// Cozy customization
+export enum FieldSubType {
+  Default = 0,
+  ExpirationDate = 1,
+}
+// Cozy customization end

--- a/libs/common/src/models/api/field.api.ts
+++ b/libs/common/src/models/api/field.api.ts
@@ -1,11 +1,17 @@
+import { FieldSubType } from "../../enums/fieldSubType";
 import { FieldType } from "../../enums/fieldType";
 import { LinkedIdType } from "../../enums/linkedIdType";
+import { ExpirationDateData } from "../../vault/models/data/expiration-date.data";
 import { BaseResponse } from "../response/base.response";
 
 export class FieldApi extends BaseResponse {
   name: string;
   value: string;
   type: FieldType;
+  // Cozy customization
+  subtype: FieldSubType;
+  expirationData: ExpirationDateData;
+  // Cozy customization end
   linkedId: LinkedIdType;
 
   constructor(data: any = null) {
@@ -14,6 +20,10 @@ export class FieldApi extends BaseResponse {
       return;
     }
     this.type = this.getResponseProperty("Type");
+    // Cozy customization
+    this.subtype = this.getResponseProperty("Subtype");
+    this.expirationData = this.getResponseProperty("ExpirationData");
+    // Cozy customization end
     this.name = this.getResponseProperty("Name");
     this.value = this.getResponseProperty("Value");
     this.linkedId = this.getResponseProperty("linkedId");

--- a/libs/common/src/vault/models/data/expiration-date.data.ts
+++ b/libs/common/src/vault/models/data/expiration-date.data.ts
@@ -1,0 +1,7 @@
+// Cozy customization
+export type ExpirationDateData = {
+  isExpired: boolean;
+  isExpiringSoon: boolean;
+  expirationDate: string;
+};
+// Cozy customization end

--- a/libs/common/src/vault/models/data/field.data.ts
+++ b/libs/common/src/vault/models/data/field.data.ts
@@ -1,9 +1,16 @@
+import { FieldSubType } from "../../../enums/fieldSubType";
 import { FieldType } from "../../../enums/fieldType";
 import { LinkedIdType } from "../../../enums/linkedIdType";
 import { FieldApi } from "../../../models/api/field.api";
 
+import { ExpirationDateData } from "./expiration-date.data";
+
 export class FieldData {
   type: FieldType;
+  // Cozy customization
+  subtype: FieldSubType;
+  expirationData: ExpirationDateData;
+  // Cozy customization end
   name: string;
   value: string;
   linkedId: LinkedIdType;
@@ -13,6 +20,10 @@ export class FieldData {
       return;
     }
     this.type = response.type;
+    // Cozy customization
+    this.subtype = response.subtype;
+    this.expirationData = response.expirationData;
+    // Cozy customization end
     this.name = response.name;
     this.value = response.value;
     this.linkedId = response.linkedId;

--- a/libs/common/src/vault/models/domain/field.ts
+++ b/libs/common/src/vault/models/domain/field.ts
@@ -1,10 +1,12 @@
 import { Jsonify } from "type-fest";
 
+import { FieldSubType } from "../../../enums/fieldSubType";
 import { FieldType } from "../../../enums/fieldType";
 import { LinkedIdType } from "../../../enums/linkedIdType";
 import Domain from "../../../models/domain/domain-base";
 import { EncString } from "../../../models/domain/enc-string";
 import { SymmetricCryptoKey } from "../../../models/domain/symmetric-crypto-key";
+import { ExpirationDateData } from "../data/expiration-date.data";
 import { FieldData } from "../data/field.data";
 import { FieldView } from "../view/field.view";
 
@@ -13,6 +15,10 @@ export class Field extends Domain {
   value: EncString;
   type: FieldType;
   linkedId: LinkedIdType;
+  // Cozy customization
+  subtype: FieldSubType;
+  expirationData: ExpirationDateData;
+  // Cozy customization end
 
   constructor(obj?: FieldData) {
     super();
@@ -21,6 +27,10 @@ export class Field extends Domain {
     }
 
     this.type = obj.type;
+    // Cozy customization
+    this.subtype = obj.subtype;
+    this.expirationData = obj.expirationData;
+    // Cozy customization end
     this.linkedId = obj.linkedId;
     this.buildDomainModel(
       this,

--- a/libs/common/src/vault/models/view/field.view.ts
+++ b/libs/common/src/vault/models/view/field.view.ts
@@ -1,14 +1,20 @@
 import { Jsonify } from "type-fest";
 
+import { FieldSubType } from "../../../enums/fieldSubType";
 import { FieldType } from "../../../enums/fieldType";
 import { LinkedIdType } from "../../../enums/linkedIdType";
 import { View } from "../../../models/view/view";
+import { ExpirationDateData } from "../data/expiration-date.data";
 import { Field } from "../domain/field";
 
 export class FieldView implements View {
   name: string = null;
   value: string = null;
   type: FieldType = null;
+  // Cozy customization
+  subtype: FieldSubType = null;
+  expirationData: ExpirationDateData = null;
+  // Cozy customization end
   newField = false; // Marks if the field is new and hasn't been saved
   showValue = false;
   showCount = false;
@@ -20,6 +26,10 @@ export class FieldView implements View {
     }
 
     this.type = f.type;
+    // Cozy customization
+    this.subtype = f.subtype;
+    this.expirationData = f.expirationData;
+    // Cozy customization end
     this.linkedId = f.linkedId;
   }
 

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -244,6 +244,10 @@ export class CipherService implements CipherServiceAbstraction {
   async encryptField(fieldModel: FieldView, key: SymmetricCryptoKey): Promise<Field> {
     const field = new Field();
     field.type = fieldModel.type;
+    // Cozy customization
+    field.subtype = fieldModel.subtype;
+    field.expirationData = fieldModel.expirationData;
+    // Cozy customization end
     field.linkedId = fieldModel.linkedId;
     // normalize boolean type field values
     if (fieldModel.type === FieldType.Boolean && fieldModel.value !== "true") {

--- a/libs/cozy/note.helper.ts
+++ b/libs/cozy/note.helper.ts
@@ -41,9 +41,9 @@ export const convertNoteToCipherResponse = async (
   cipherView.type = CipherType.Paper;
   cipherView.paper = new PaperView();
   cipherView.paper.type = PaperType.Note;
-  cipherView.paper.noteContent = await client
-    .getStackClient()
-    .fetchJSON("GET", "/notes/" + paper.id + "/text");
+  cipherView.paper.noteContent =
+    (await client.getStackClient().fetchJSON("GET", "/notes/" + paper.id + "/text")) || "/";
+
   cipherView.paper.illustrationThumbnailUrl = noteIllustrationUrl;
   cipherView.paper.illustrationUrl = noteIllustrationUrl;
   cipherView.paper.qualificationLabel = paper.metadata.qualification.label;

--- a/libs/cozy/paper.helper.ts
+++ b/libs/cozy/paper.helper.ts
@@ -54,6 +54,7 @@ export const convertPaperToCipherResponse = async (
   cipherView.paper.illustrationUrl = buildIllustrationUrl(paper, baseUrl);
   cipherView.paper.qualificationLabel = paper.metadata.qualification.label;
   cipherView.fields = buildFieldsFromPaper(i18nService, paper);
+  cipherView.favorite = !!paper.cozyMetadata.favorite;
 
   const cipherEncrypted = await cipherService.encrypt(cipherView);
   const cipherViewEncrypted = new CipherView(cipherEncrypted);
@@ -68,6 +69,7 @@ export const convertPaperToCipherResponse = async (
   cipherViewResponse.paper.illustrationUrl = cipherView.paper.illustrationUrl;
   cipherViewResponse.paper.qualificationLabel = cipherView.paper.qualificationLabel;
   cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields);
+  cipherViewResponse.favorite = cipherEncrypted.favorite;
 
   return cipherViewResponse;
 };

--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 // Cozy customization
-import { Q } from "cozy-client";
 import CozyClient from "cozy-client/types/CozyClient";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
@@ -12,96 +11,7 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import { convertNoteToCipherResponse, isNote, fetchNoteIllustrationUrl } from "./note.helper";
 import { convertPaperToCipherResponse } from "./paper.helper";
-
-const fetchPapers = async (client: CozyClient) => {
-  const filesQueryByLabels = buildFilesQueryWithQualificationLabel();
-
-  const data = await client.queryAll(filesQueryByLabels.definition(), filesQueryByLabels.options);
-
-  const hydratedData = client.hydrateDocuments("io.cozy.files", data);
-
-  return hydratedData;
-};
-
-const fetchPaper = async (client: CozyClient, _id: string) => {
-  const fileQueryWithContact = buildFileQueryWithContacts(_id);
-
-  const { data } = await client.query(
-    fileQueryWithContact.definition(),
-    fileQueryWithContact.options
-  );
-
-  return data[0];
-};
-
-export const buildFilesQueryWithQualificationLabel = () => {
-  const select = [
-    "name",
-    "mime",
-    "referenced_by",
-    "metadata.country",
-    "metadata.datetime",
-    "metadata.expirationDate",
-    "metadata.noticePeriod",
-    "metadata.qualification.label",
-    "metadata.referencedDate",
-    "metadata.number",
-    "metadata.contractType",
-    "metadata.refTaxIncome",
-    "metadata.title",
-    "metadata.AObtentionDate",
-    "metadata.BObtentionDate",
-    "metadata.CObtentionDate",
-    "metadata.DObtentionDate",
-    "metadata.page",
-    "metadata.version",
-    "cozyMetadata.createdByApp",
-    "cozyMetadata.sourceAccountIdentifier",
-    "cozyMetadata.favorite",
-    "created_at",
-    "dir_id",
-    "updated_at",
-    "type",
-    "trashed",
-  ];
-
-  return {
-    definition: () =>
-      Q("io.cozy.files")
-        .where({
-          type: "file",
-          trashed: false,
-        })
-        .partialIndex({
-          "metadata.qualification.label": {
-            $exists: true,
-          },
-          "cozyMetadata.createdByApp": { $exists: true },
-        })
-        .select(select)
-        .limitBy(1000)
-        .include(["contacts"])
-        .indexFields(["type", "trashed"]),
-    options: {
-      as: `io.cozy.files/metadata_qualification_label`,
-    },
-  };
-};
-
-export const buildFileQueryWithContacts = (_id: string) => {
-  return {
-    definition: () =>
-      Q("io.cozy.files")
-        .where({
-          _id: _id,
-        })
-        .limitBy(1)
-        .include(["contacts"]),
-    options: {
-      as: `io.cozy.files/byIdWithContacts`,
-    },
-  };
-};
+import { fetchPapers, fetchPaper } from "./queries";
 
 const convertPapersAsCiphers = async (
   cipherService: any,

--- a/libs/cozy/queries.ts
+++ b/libs/cozy/queries.ts
@@ -1,0 +1,92 @@
+import { Q } from "cozy-client";
+import CozyClient from "cozy-client/types/CozyClient";
+
+const buildFilesQueryWithQualificationLabel = () => {
+  const select = [
+    "name",
+    "mime",
+    "referenced_by",
+    "metadata.country",
+    "metadata.datetime",
+    "metadata.expirationDate",
+    "metadata.noticePeriod",
+    "metadata.qualification.label",
+    "metadata.referencedDate",
+    "metadata.number",
+    "metadata.contractType",
+    "metadata.refTaxIncome",
+    "metadata.title",
+    "metadata.AObtentionDate",
+    "metadata.BObtentionDate",
+    "metadata.CObtentionDate",
+    "metadata.DObtentionDate",
+    "metadata.page",
+    "metadata.version",
+    "cozyMetadata.createdByApp",
+    "cozyMetadata.sourceAccountIdentifier",
+    "cozyMetadata.favorite",
+    "created_at",
+    "dir_id",
+    "updated_at",
+    "type",
+    "trashed",
+  ];
+
+  return {
+    definition: () =>
+      Q("io.cozy.files")
+        .where({
+          type: "file",
+          trashed: false,
+        })
+        .partialIndex({
+          "metadata.qualification.label": {
+            $exists: true,
+          },
+          "cozyMetadata.createdByApp": { $exists: true },
+        })
+        .select(select)
+        .limitBy(1000)
+        .include(["contacts"])
+        .indexFields(["type", "trashed"]),
+    options: {
+      as: `io.cozy.files/metadata_qualification_label`,
+    },
+  };
+};
+
+const buildFileQueryWithContacts = (_id: string) => {
+  return {
+    definition: () =>
+      Q("io.cozy.files")
+        .where({
+          _id: _id,
+        })
+        .limitBy(1)
+        .include(["contacts"]),
+    options: {
+      as: `io.cozy.files/byIdWithContacts`,
+    },
+  };
+};
+
+export const fetchPapers = async (client: CozyClient) => {
+  const filesQueryByLabels = buildFilesQueryWithQualificationLabel();
+
+  const data = await client.queryAll(filesQueryByLabels.definition(), filesQueryByLabels.options);
+
+  const hydratedData = client.hydrateDocuments("io.cozy.files", data);
+
+  return hydratedData;
+};
+
+export const fetchPaper = async (client: CozyClient, _id: string) => {
+  const fileQueryWithContact = buildFileQueryWithContacts(_id);
+
+  const { data } = await client.query(
+    fileQueryWithContact.definition(),
+    fileQueryWithContact.options
+  );
+
+  return data[0];
+};


### PR DESCRIPTION
**Favorite**

Allow to favorite/unfavorite a paper directly from the view mode (not from the edit mode). Very different than for bitwarden ciphers. It saves the favorite value in the in.cozy.files `cozyMetadata`.

Related : https://github.com/cozy/cozy-stack/pull/4355 https://github.com/cozy/cozy-pass-web/pull/122

**Expiration annotation**

Display an expiration annotation for expiration date in paper fields (can be 'Expired' or 'Expire in x days').

![image](https://github.com/cozy/cozy-keys-browser/assets/10849491/7e331ead-12ab-4f93-860d-1368e3247b02)

**Misc**

1 bug fix and 1 refactoring