### PR TITLE
Do not fail sync when error during paper import

### DIFF
--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -123,7 +123,7 @@ export const fetchPapersAndConvertAsCiphers = async (
   } catch (e) {
     console.log("Error while fetching papers and converting them as ciphers", e);
 
-    throw e;
+    return [];
   }
 };
 


### PR DESCRIPTION
If something failed during paper import, it was failing the full sync process making the extension unusable. Now we return an empty array if there is an error during paper import so the rest of the extension will work fine. There will be only no papers.