### PR TITLE
fix: Correctly display tab icons on firefox

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -302,6 +302,10 @@ This class is responsible of changing tabs colors :
 .tab-icon-cozy {
   color: $gray-light;
 
+  .bwi {
+    color: $gray-light;
+  }
+
   &:hover,
   &:active,
   &.active {
@@ -314,6 +318,7 @@ This class is responsible of changing tabs colors :
       background-color: $brand-primary;
       @include themify($themes) {
         background-color: themed("primaryColor");
+        color: themed("primaryColor");
       }
     }
   }


### PR DESCRIPTION
In order to keep consistent height on tab icons, we use a `::before` CSS rule that inject `\f071` character

This character should not be visible thanks to mask-image rules and to the character form

However on Firefox, this character has a different form and so it is visible

To fix this, we choose to set the same font color as the background color

In the future we may want to find a solution to remove the need for this special character

### Before
![image](https://github.com/cozy/cozy-keys-browser/assets/1884255/38b66c5a-eb5a-4202-849c-728cc0346b86)

### After
![image](https://github.com/cozy/cozy-keys-browser/assets/1884255/97d343ad-12d9-4773-b49c-40ae614cb0d8)
