### PR TITLE
Display avatar in contact view

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -424,7 +424,7 @@ li.active .icon-cozy-inline > svg {
   content: url("../images/icon-file-type-text.png");
 }
 
-.paper-illustration {
+.cipher-illustration {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -434,7 +434,7 @@ li.active .icon-cozy-inline > svg {
   padding-bottom: 15px;
 }
 
-.paper-illustration img {
+.cipher-illustration img {
   max-height: 96px; // size of the tiny thumbnail
   object-fit: contain;
 }

--- a/apps/browser/src/vault/popup/components/vault/view.component.html
+++ b/apps/browser/src/vault/popup/components/vault/view.component.html
@@ -36,12 +36,16 @@
 </header>
 <main tabindex="-1" *ngIf="cipher">
   <!-- Cozy customization -->
-  <div *ngIf="cipher.type === cipherType.Paper" class="paper-illustration">
+  <div *ngIf="cipher.type === cipherType.Paper" class="cipher-illustration">
     <img
       [src]="sanitize(cipher.paper.illustrationThumbnailUrl)"
       (click)="openWebApp()"
       (error)="onIllustrationError()"
     />
+  </div>
+  <div *ngIf="cipher.type === cipherType.Contact" class="cipher-illustration">
+    <app-vault-contact-avatar [initials]="cipher.contact.initials" [size]="96">
+    </app-vault-contact-avatar>
   </div>
   <!-- Cozy customization end -->
   <div class="box">


### PR DESCRIPTION
paper-illustration has been renamed to cipher-illustration because it serves both for paper illustration (thumbnail) and contact illustration (avatar).

![image](https://github.com/cozy/cozy-keys-browser/assets/10849491/20158d99-ecf4-486e-b306-16c3a9e1a78e)
