### PR TITLE
feat: Add realtime for contacts and papers

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -358,7 +358,8 @@ export default class MainBackground {
       this.apiService,
       this.messagingService,
       this.cipherService,
-      this.stateService
+      this.stateService,
+      this.i18nService
     );
     // Cozy customization end
     this.folderService = new BrowserFolderService(

--- a/apps/browser/src/cozy/realtime/RealtimeNotifications.ts
+++ b/apps/browser/src/cozy/realtime/RealtimeNotifications.ts
@@ -1,0 +1,64 @@
+import CozyClient from "cozy-client";
+
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
+
+import { convertContactToCipherResponse } from "../../../../../libs/cozy/contact.helper"
+
+export class RealTimeNotifications {
+  constructor(
+    private messagingService: MessagingService,
+    private cipherService: CipherService,
+    private i18nService: I18nService,
+    private client: CozyClient
+  ) {}
+
+  async init(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error reatime item is not typed as it is dynamically injected at runtime
+    const realtime = this.client.plugins.realtime;
+
+    const doctypeContact = "io.cozy.contacts";
+    await realtime.subscribe(
+      "created",
+      doctypeContact,
+      this.dispatchCreateOrUpdateContact.bind(this)
+    );
+    await realtime.subscribe(
+      "updated",
+      doctypeContact,
+      this.dispatchCreateOrUpdateContact.bind(this)
+    );
+    await realtime.subscribe("deleted", doctypeContact, this.dispatchDeleteCipher.bind(this));
+  }
+
+  async unregister() {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error reatime item is not typed as it is dynamically injected at runtime
+    const realtime = this.client.plugins.realtime;
+
+    const doctypeContact = "io.cozy.contacts";
+    await realtime.unsubscribe("created", doctypeContact, this.dispatchCreateOrUpdateContact);
+    await realtime.unsubscribe("updated", doctypeContact, this.dispatchCreateOrUpdateContact);
+    await realtime.unsubscribe("deleted", doctypeContact, this.dispatchDeleteCipher);
+  }
+
+  async dispatchCreateOrUpdateContact(data: any) {
+    const cipherResponse = await convertContactToCipherResponse(
+      this.cipherService,
+      this.i18nService,
+      data
+    );
+    await this.cipherService.upsert(new CipherData(cipherResponse));
+    this.messagingService.send("syncedUpsertedCipher", { cipherId: data._id });
+    this.messagingService.send("syncCompleted", { successfully: true });
+  }
+
+  async dispatchDeleteCipher(data: any) {
+    await this.cipherService.delete(data._id);
+    this.messagingService.send("syncedDeletedCipher", { cipherId: data._id });
+    this.messagingService.send("syncCompleted", { successfully: true });
+  }
+}

--- a/apps/browser/src/cozy/realtime/RealtimeNotifications.ts
+++ b/apps/browser/src/cozy/realtime/RealtimeNotifications.ts
@@ -45,6 +45,9 @@ export class RealTimeNotifications {
     // We don't want to listen Creation as it is always followed by an Update notification with more data
     await realtime.subscribe("updated", doctypePaper, this.dispatchUpdatePaper.bind(this));
     await realtime.subscribe("deleted", doctypePaper, this.dispatchDeleteCipher.bind(this));
+
+    const doctypeThumbnail = "io.cozy.files.thumbnails";
+    await realtime.subscribe("created", doctypeThumbnail, this.dispatchCreateThumbnail.bind(this));
   }
 
   async unregister() {
@@ -60,6 +63,9 @@ export class RealTimeNotifications {
     const doctypePaper = "io.cozy.files";
     await realtime.unsubscribe("updated", doctypePaper, this.dispatchUpdatePaper);
     await realtime.unsubscribe("deleted", doctypePaper, this.dispatchDeleteCipher);
+
+    const doctypeThumbnail = "io.cozy.files.thumbnails";
+    await realtime.unsubscribe("created", doctypeThumbnail, this.dispatchCreateThumbnail);
   }
 
   async dispatchCreateOrUpdateContact(data: any) {
@@ -129,5 +135,15 @@ export class RealTimeNotifications {
     await this.cipherService.upsert(new CipherData(cipherResponse));
     this.messagingService.send("syncedUpsertedCipher", { cipherId: paperId });
     this.messagingService.send("syncCompleted", { successfully: true });
+  }
+
+  async dispatchCreateThumbnail(data: any) {
+    const cipher = await this.cipherService.get(data._id);
+
+    if (cipher === null) {
+      return;
+    }
+
+    this.upsertPaperFromId(data._id);
   }
 }

--- a/apps/browser/src/cozy/realtime/RealtimeNotifications.ts
+++ b/apps/browser/src/cozy/realtime/RealtimeNotifications.ts
@@ -4,8 +4,16 @@ import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { MessagingService } from "@bitwarden/common/abstractions/messaging.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
+import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.response";
 
-import { convertContactToCipherResponse } from "../../../../../libs/cozy/contact.helper"
+import { convertContactToCipherResponse } from "../../../../../libs/cozy/contact.helper";
+import {
+  convertNoteToCipherResponse,
+  fetchNoteIllustrationUrl,
+  isNote,
+} from "../../../../../libs/cozy/note.helper";
+import { convertPaperToCipherResponse } from "../../../../../libs/cozy/paper.helper";
+import { fetchPaper } from "../../../../../libs/cozy/queries";
 
 export class RealTimeNotifications {
   constructor(
@@ -32,6 +40,11 @@ export class RealTimeNotifications {
       this.dispatchCreateOrUpdateContact.bind(this)
     );
     await realtime.subscribe("deleted", doctypeContact, this.dispatchDeleteCipher.bind(this));
+
+    const doctypePaper = "io.cozy.files";
+    // We don't want to listen Creation as it is always followed by an Update notification with more data
+    await realtime.subscribe("updated", doctypePaper, this.dispatchUpdatePaper.bind(this));
+    await realtime.subscribe("deleted", doctypePaper, this.dispatchDeleteCipher.bind(this));
   }
 
   async unregister() {
@@ -43,13 +56,18 @@ export class RealTimeNotifications {
     await realtime.unsubscribe("created", doctypeContact, this.dispatchCreateOrUpdateContact);
     await realtime.unsubscribe("updated", doctypeContact, this.dispatchCreateOrUpdateContact);
     await realtime.unsubscribe("deleted", doctypeContact, this.dispatchDeleteCipher);
+
+    const doctypePaper = "io.cozy.files";
+    await realtime.unsubscribe("updated", doctypePaper, this.dispatchUpdatePaper);
+    await realtime.unsubscribe("deleted", doctypePaper, this.dispatchDeleteCipher);
   }
 
   async dispatchCreateOrUpdateContact(data: any) {
     const cipherResponse = await convertContactToCipherResponse(
       this.cipherService,
       this.i18nService,
-      data
+      data,
+      null
     );
     await this.cipherService.upsert(new CipherData(cipherResponse));
     this.messagingService.send("syncedUpsertedCipher", { cipherId: data._id });
@@ -59,6 +77,57 @@ export class RealTimeNotifications {
   async dispatchDeleteCipher(data: any) {
     await this.cipherService.delete(data._id);
     this.messagingService.send("syncedDeletedCipher", { cipherId: data._id });
+    this.messagingService.send("syncCompleted", { successfully: true });
+  }
+
+  async dispatchUpdatePaper(data: any) {
+    if (data.type !== "file") {
+      return;
+    }
+    if (!data.metadata?.qualification?.label) {
+      return;
+    }
+    if (data.dir_id === "io.cozy.files.trash-dir") {
+      // We don't want to display trashed papers in the extension's bin so we remove them from the vault
+      return this.dispatchDeleteCipher(data);
+    }
+
+    await this.upsertPaperFromId(data._id);
+  }
+
+  async upsertPaperFromId(paperId: string) {
+    const itemFromDb = await fetchPaper(this.client, paperId);
+    const hydratedData = this.client.hydrateDocuments("io.cozy.files", [itemFromDb])[0];
+
+    let cipherResponse: CipherResponse;
+    if (isNote(itemFromDb)) {
+      const noteIllustrationUrl = await fetchNoteIllustrationUrl(this.client);
+
+      cipherResponse = await convertNoteToCipherResponse(
+        this.cipherService,
+        this.i18nService,
+        hydratedData,
+        null,
+        {
+          noteIllustrationUrl,
+        }
+      );
+    } else {
+      const baseUrl = this.client.getStackClient().uri;
+
+      cipherResponse = await convertPaperToCipherResponse(
+        this.cipherService,
+        this.i18nService,
+        hydratedData,
+        null,
+        {
+          baseUrl,
+        }
+      );
+    }
+
+    await this.cipherService.upsert(new CipherData(cipherResponse));
+    this.messagingService.send("syncedUpsertedCipher", { cipherId: paperId });
     this.messagingService.send("syncCompleted", { successfully: true });
   }
 }

--- a/libs/cozy/contact.helper.ts
+++ b/libs/cozy/contact.helper.ts
@@ -26,7 +26,7 @@ export const convertContactToCipherResponse = async (
   key: SymmetricCryptoKey
 ): Promise<CipherResponse> => {
   const cipherView = new CipherView();
-  cipherView.id = contact.id;
+  cipherView.id = contact.id ?? contact._id;
   cipherView.name = contact.displayName;
   cipherView.type = CipherType.Contact;
   cipherView.contact = new ContactView();

--- a/libs/cozy/paper.helper.ts
+++ b/libs/cozy/paper.helper.ts
@@ -30,7 +30,7 @@ const buildIllustrationThumbnailUrl = (paper: any, baseUrl: string) => {
   return paper.links.tiny ? new URL(paper.links.tiny, baseUrl).toString() : DEFAULT_THUMBNAIL_URL;
 };
 
-const buildIllustrationUrl = (paper: any, baseUrl: string) => {
+export const buildIllustrationUrl = (paper: any, baseUrl: string) => {
   return paper.links.medium
     ? new URL(paper.links.medium, baseUrl).toString()
     : DEFAULT_THUMBNAIL_URL;

--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -15,7 +15,7 @@ import { convertNoteToCipherResponse, isNote, fetchNoteIllustrationUrl } from ".
 import { convertPaperToCipherResponse } from "./paper.helper";
 import { fetchPapers, fetchPaper } from "./queries";
 
-const convertPapersAsCiphers = async (
+export const convertPapersAsCiphers = async (
   cipherService: any,
   cryptoService: CryptoService,
   i18nService: any,

--- a/libs/cozy/queries.ts
+++ b/libs/cozy/queries.ts
@@ -43,17 +43,12 @@ const buildFilesQueryWithQualificationLabel = () => {
   };
 };
 
-const buildFileQueryWithContacts = (_id: string) => {
+const buildFileQueryById = (_id: string) => {
   return {
-    definition: () =>
-      Q("io.cozy.files")
-        .where({
-          _id: _id,
-        })
-        .limitBy(1)
-        .include(["contacts"]),
+    definition: () => Q("io.cozy.files").getById(_id),
     options: {
-      as: `io.cozy.files/byIdWithContacts`,
+      as: `io.cozy.files/byId`,
+      singleDocData: true,
     },
   };
 };
@@ -69,14 +64,14 @@ export const fetchPapers = async (client: CozyClient) => {
 };
 
 export const fetchPaper = async (client: CozyClient, _id: string) => {
-  const fileQueryWithContact = buildFileQueryWithContacts(_id);
+  const fileQueryWithContact = buildFileQueryById(_id);
 
   const { data } = await client.query(
     fileQueryWithContact.definition(),
     fileQueryWithContact.options
   );
 
-  return data[0];
+  return data;
 };
 
 // Contacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "cozy-device-helper": ">1.12.0",
         "cozy-flags": ">2.8.6",
         "cozy-logger": ">1.7.0",
+        "cozy-realtime": "5.0.0",
         "cozy-ui": "105.5.0",
         "date-input-polyfill": "^2.14.0",
         "duo_web_sdk": "github:duosecurity/duo_web_sdk",
@@ -21108,9 +21109,9 @@
       }
     },
     "node_modules/cozy-device-helper": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/cozy-device-helper/-/cozy-device-helper-2.7.0.tgz",
-      "integrity": "sha512-jMzW7s4IDuMivbsP8fo1IWW1z5l0wJ0u440E0fQmdsi+Zm/L9GXFKthLuuceYqXlH6c/APUCfpozJqjFMMHU1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cozy-device-helper/-/cozy-device-helper-3.0.0.tgz",
+      "integrity": "sha512-dkwQ8I0B2TiGs6MDdvSWOJKHMUwTHJegr67E3hpsupy5G9Z52dyjYtbK6bfoj0ykhit15fVI7bi8ivDyoM1oRg==",
       "dependencies": {
         "lodash": "^4.17.19"
       }
@@ -21206,6 +21207,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cozy-realtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cozy-realtime/-/cozy-realtime-5.0.0.tgz",
+      "integrity": "sha512-nNUxHAYsfz3ZTKNNOm5AT6Hc5dr7qthei1/u0GWRn6plnPy6me69J0lxle1tMq/9QZ9DNSxSbHCCz3UVHuGamg==",
+      "dependencies": {
+        "@cozy/minilog": "^1.0.0",
+        "cozy-device-helper": "^3.0.0"
+      },
+      "peerDependencies": {
+        "cozy-client": ">=13.15.1"
       }
     },
     "node_modules/cozy-stack-client": {
@@ -65003,9 +65016,9 @@
       }
     },
     "cozy-device-helper": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/cozy-device-helper/-/cozy-device-helper-2.7.0.tgz",
-      "integrity": "sha512-jMzW7s4IDuMivbsP8fo1IWW1z5l0wJ0u440E0fQmdsi+Zm/L9GXFKthLuuceYqXlH6c/APUCfpozJqjFMMHU1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cozy-device-helper/-/cozy-device-helper-3.0.0.tgz",
+      "integrity": "sha512-dkwQ8I0B2TiGs6MDdvSWOJKHMUwTHJegr67E3hpsupy5G9Z52dyjYtbK6bfoj0ykhit15fVI7bi8ivDyoM1oRg==",
       "requires": {
         "lodash": "^4.17.19"
       }
@@ -65081,6 +65094,15 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "cozy-realtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cozy-realtime/-/cozy-realtime-5.0.0.tgz",
+      "integrity": "sha512-nNUxHAYsfz3ZTKNNOm5AT6Hc5dr7qthei1/u0GWRn6plnPy6me69J0lxle1tMq/9QZ9DNSxSbHCCz3UVHuGamg==",
+      "requires": {
+        "@cozy/minilog": "^1.0.0",
+        "cozy-device-helper": "^3.0.0"
       }
     },
     "cozy-stack-client": {

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "cozy-device-helper": ">1.12.0",
     "cozy-flags": ">2.8.6",
     "cozy-logger": ">1.7.0",
+    "cozy-realtime": "5.0.0",
     "cozy-ui": "105.5.0",
     "date-input-polyfill": "^2.14.0",
     "duo_web_sdk": "github:duosecurity/duo_web_sdk",


### PR DESCRIPTION
We want the extension to keep synchronized with the Cozy when a contact or a paper is created, edited or deleted from the cozy-contact webapp

The NotificationsService is responsible to keep the vault synchronized item is created outside of the extension

This service only works for Bitwarden items like ciphers or organization, but newly added Contacts and Papers are Cozy's concepts and so are not propagated through the Bitwarden's realtime mechanism

To allow this we must rely on the CozyClient's realtime capabilities

The first idea was to integrate those into the NotificationsService class, but we found that it can be fully isolated into a Cozy specific class. So we created the RealtimeNotifications class that is called from inside CozyClientService