### PR TITLE
Convert papers/contacts to CipherData instead of CipherResponse

### DIFF
--- a/libs/common/src/vault/models/domain/cipher.ts
+++ b/libs/common/src/vault/models/domain/cipher.ts
@@ -248,6 +248,12 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
       case CipherType.Identity:
         c.identity = this.identity.toIdentityData();
         break;
+      case CipherType.Paper:
+        c.paper = this.paper.toPaperData();
+        break;
+      case CipherType.Contact:
+        c.contact = this.contact.toContactData();
+        break;
       default:
         break;
     }

--- a/libs/common/src/vault/models/domain/contact.ts
+++ b/libs/common/src/vault/models/domain/contact.ts
@@ -45,5 +45,23 @@ export class Contact extends Domain {
       encKey
     );
   }
+
+  toContactData(): ContactData {
+    const c = new ContactData();
+    c.me = this.me;
+    this.buildDataModel(
+      this,
+      c,
+      {
+        displayName: null,
+        initials: null,
+        primaryEmail: null,
+        primaryPhone: null,
+      },
+      []
+    );
+
+    return c;
+  }
 }
 // Cozy customization end

--- a/libs/common/src/vault/models/domain/field.ts
+++ b/libs/common/src/vault/models/domain/field.ts
@@ -64,6 +64,11 @@ export class Field extends Domain {
 
   toFieldData(): FieldData {
     const f = new FieldData();
+    f.id = this.id;
+    f.parentId = this.parentId;
+    f.subtype = this.subtype;
+    f.expirationData = this.expirationData;
+    f.label = this.label;
     this.buildDataModel(
       this,
       f,

--- a/libs/common/src/vault/models/domain/paper.ts
+++ b/libs/common/src/vault/models/domain/paper.ts
@@ -49,5 +49,24 @@ export class Paper extends Domain {
       encKey
     );
   }
+
+  toPaperData(): PaperData {
+    const p = new PaperData();
+    p.type = this.type;
+    this.buildDataModel(
+      this,
+      p,
+      {
+        ownerName: null,
+        illustrationThumbnailUrl: null,
+        illustrationUrl: null,
+        qualificationLabel: null,
+        noteContent: null,
+      },
+      []
+    );
+
+    return p;
+  }
 }
 // Cozy customization end

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -1277,6 +1277,7 @@ export class CipherService implements CipherServiceAbstraction {
         return;
       case CipherType.Contact:
         cipher.contact = new Contact();
+        cipher.contact.me = model.contact.me;
         await this.encryptObjProperty(
           model.contact,
           cipher.contact,

--- a/libs/common/src/vault/services/sync/sync.service.ts
+++ b/libs/common/src/vault/services/sync/sync.service.ts
@@ -110,6 +110,7 @@ export class SyncService implements SyncServiceAbstraction {
       await this.syncProfile(response.profile);
       await this.syncFolders(response.folders);
       await this.syncCollections(response.collections);
+      await this.syncCiphers(response.ciphers);
 
       // Cozy customization
       await this.cozyClientService.getClientInstance();
@@ -132,15 +133,14 @@ export class SyncService implements SyncServiceAbstraction {
       const [papersPromise, contactsPromise] = await Promise.allSettled(fetchPromises);
 
       if (papersPromise.status === "fulfilled") {
-        response.ciphers.push(...papersPromise.value);
+        await this.cipherService.upsert(papersPromise.value);
       }
 
       if (contactsPromise.status === "fulfilled") {
-        response.ciphers.push(...contactsPromise.value);
+        await this.cipherService.upsert(contactsPromise.value);
       }
       // Cozy customization end
 
-      await this.syncCiphers(response.ciphers);
       await this.syncSends(response.sends);
       await this.syncSettings(response.domains);
       await this.syncPolicies(response.policies);

--- a/libs/cozy/contact.helper.ts
+++ b/libs/cozy/contact.helper.ts
@@ -1,4 +1,5 @@
 import { models } from "cozy-client";
+import { IOCozyContact } from "cozy-client/types/types";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/models/domain/symmetric-crypto-key";
@@ -12,20 +13,23 @@ const { getInitials } = models.contact;
 
 import { buildFieldsFromContact } from "./fields.helper";
 
-const getPrimaryEmail = (contact: any): string | undefined => {
-  return contact.email?.find((email: any) => email.primary)?.address;
+const getPrimaryEmail = (contact: IOCozyContact): string | undefined => {
+  return contact.email?.find((email) => email.primary)?.address;
 };
 
-const getPrimaryPhone = (contact: any): string | undefined => {
-  return contact.phone?.find((phone: any) => phone.primary)?.number;
+const getPrimaryPhone = (contact: IOCozyContact): string | undefined => {
+  return contact.phone?.find((phone) => phone.primary)?.number;
 };
 
 export const convertContactToCipherData = async (
   cipherService: CipherService,
   i18nService: I18nService,
-  contact: any,
+  contact: IOCozyContact,
   key?: SymmetricCryptoKey
 ): Promise<CipherData> => {
+  // Temporary type fix because contact.cozyMetadata is not properly typed
+  const cozyMetadata = contact.cozyMetadata as any;
+
   const cipherView = new CipherView();
   cipherView.id = contact.id ?? contact._id;
   cipherView.name = contact.displayName;
@@ -35,11 +39,11 @@ export const convertContactToCipherData = async (
   cipherView.contact.initials = getInitials(contact);
   cipherView.contact.primaryEmail = getPrimaryEmail(contact);
   cipherView.contact.primaryPhone = getPrimaryPhone(contact);
-  cipherView.favorite = !!contact.cozyMetadata?.favorite;
+  cipherView.favorite = !!cozyMetadata?.favorite;
   cipherView.fields = buildFieldsFromContact(i18nService, contact);
   cipherView.contact.me = contact.me;
-  cipherView.creationDate = new Date(contact.cozyMetadata?.createdAt);
-  cipherView.revisionDate = new Date(contact.cozyMetadata?.updatedAt);
+  cipherView.creationDate = new Date(cozyMetadata?.createdAt);
+  cipherView.revisionDate = new Date(cozyMetadata?.updatedAt);
 
   const cipherEncrypted = await cipherService.encrypt(cipherView, key);
 

--- a/libs/cozy/contact.helper.ts
+++ b/libs/cozy/contact.helper.ts
@@ -1,6 +1,8 @@
 import { models } from "cozy-client";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { SymmetricCryptoKey } from "@bitwarden/common/models/domain/symmetric-crypto-key";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -19,8 +21,8 @@ const getPrimaryPhone = (contact: any): string | undefined => {
 };
 
 export const convertContactToCipherData = async (
-  cipherService: any,
-  i18nService: any,
+  cipherService: CipherService,
+  i18nService: I18nService,
   contact: any,
   key?: SymmetricCryptoKey
 ): Promise<CipherData> => {

--- a/libs/cozy/contact.helper.ts
+++ b/libs/cozy/contact.helper.ts
@@ -1,15 +1,14 @@
 import { models } from "cozy-client";
 
-import { ContactApi } from "@bitwarden/common/models/api/contact.api";
 import { SymmetricCryptoKey } from "@bitwarden/common/models/domain/symmetric-crypto-key";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
-import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.response";
+import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { ContactView } from "@bitwarden/common/vault/models/view/contact.view";
 
 const { getInitials } = models.contact;
 
-import { buildFieldsFromContact, copyEncryptedFields } from "./fields.helper";
+import { buildFieldsFromContact } from "./fields.helper";
 
 const getPrimaryEmail = (contact: any): string | undefined => {
   return contact.email?.find((email: any) => email.primary)?.address;
@@ -19,12 +18,12 @@ const getPrimaryPhone = (contact: any): string | undefined => {
   return contact.phone?.find((phone: any) => phone.primary)?.number;
 };
 
-export const convertContactToCipherResponse = async (
+export const convertContactToCipherData = async (
   cipherService: any,
   i18nService: any,
   contact: any,
   key?: SymmetricCryptoKey
-): Promise<CipherResponse> => {
+): Promise<CipherData> => {
   const cipherView = new CipherView();
   cipherView.id = contact.id ?? contact._id;
   cipherView.name = contact.displayName;
@@ -36,25 +35,13 @@ export const convertContactToCipherResponse = async (
   cipherView.contact.primaryPhone = getPrimaryPhone(contact);
   cipherView.favorite = !!contact.cozyMetadata?.favorite;
   cipherView.fields = buildFieldsFromContact(i18nService, contact);
+  cipherView.contact.me = contact.me;
+  cipherView.creationDate = new Date(contact.cozyMetadata?.createdAt);
+  cipherView.revisionDate = new Date(contact.cozyMetadata?.updatedAt);
 
   const cipherEncrypted = await cipherService.encrypt(cipherView, key);
-  const cipherViewEncrypted = new CipherView(cipherEncrypted);
-  const cipherViewResponse = new CipherResponse(cipherViewEncrypted);
-  cipherViewResponse.id = cipherEncrypted.id;
-  cipherViewResponse.name = cipherEncrypted.name?.encryptedString ?? "";
-  cipherViewResponse.contact = new ContactApi();
-  cipherViewResponse.contact.displayName =
-    cipherEncrypted.contact.displayName?.encryptedString ?? "";
-  cipherViewResponse.contact.initials = cipherEncrypted.contact.initials?.encryptedString ?? "";
-  cipherViewResponse.contact.primaryEmail =
-    cipherEncrypted.contact.primaryEmail?.encryptedString ?? "";
-  cipherViewResponse.contact.primaryPhone =
-    cipherEncrypted.contact.primaryPhone?.encryptedString ?? "";
-  cipherViewResponse.favorite = cipherEncrypted.favorite;
-  cipherViewResponse.creationDate = contact.cozyMetadata?.createdAt;
-  cipherViewResponse.revisionDate = contact.cozyMetadata?.updatedAt;
-  cipherViewResponse.fields = copyEncryptedFields(cipherEncrypted.fields ?? []);
-  cipherViewResponse.contact.me = contact.me;
 
-  return cipherViewResponse;
+  const cipherData = cipherEncrypted.toCipherData();
+
+  return cipherData;
 };

--- a/libs/cozy/contactCipher.ts
+++ b/libs/cozy/contactCipher.ts
@@ -9,13 +9,15 @@ import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import { CozyClientService } from "../../apps/browser/src/popup/services/cozyClient.service";
+
 import { convertContactToCipherData } from "./contact.helper";
 import { fetchContacts, fetchContact } from "./queries";
 
 const convertContactsAsCiphers = async (
-  cipherService: any,
+  cipherService: CipherService,
   cryptoService: CryptoService,
-  i18nService: any,
+  i18nService: I18nService,
   contacts: any
 ): Promise<CipherData[]> => {
   const contactsCiphers = [];
@@ -40,10 +42,10 @@ const convertContactsAsCiphers = async (
 };
 
 export const fetchContactsAndConvertAsCiphers = async (
-  cipherService: any,
+  cipherService: CipherService,
   cryptoService: CryptoService,
-  cozyClientService: any,
-  i18nService: any
+  cozyClientService: CozyClientService,
+  i18nService: I18nService
 ): Promise<CipherData[]> => {
   const client = await cozyClientService.getClientInstance();
 
@@ -65,8 +67,8 @@ export const fetchContactsAndConvertAsCiphers = async (
     );
 
     return (await cipherService.getAll())
-      .filter((cipher: any) => cipher.type === CipherType.Contact)
-      .map((cipher: any) => cipher.toCipherData());
+      .filter((cipher) => cipher.type === CipherType.Contact)
+      .map((cipher) => cipher.toCipherData());
   }
 };
 
@@ -74,7 +76,7 @@ export const favoriteContactCipher = async (
   cipherService: CipherService,
   i18nService: I18nService,
   cipher: CipherView,
-  cozyClientService: any
+  cozyClientService: CozyClientService
 ): Promise<boolean> => {
   const client = await cozyClientService.getClientInstance();
 
@@ -101,7 +103,7 @@ export const deleteContactCipher = async (
   platformUtilsService: PlatformUtilsService,
   cipher: CipherView,
   stateService: StateService,
-  cozyClientService: any
+  cozyClientService: CozyClientService
 ): Promise<boolean> => {
   const confirmed = await platformUtilsService.showDialog(
     i18nService.t("deleteContactItemConfirmation"),

--- a/libs/cozy/contactCipher.ts
+++ b/libs/cozy/contactCipher.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 // Cozy customization
+import { IOCozyContact } from "cozy-client/types/types";
+
 import { CryptoService } from "@bitwarden/common/abstractions/crypto.service";
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUtils.service";
@@ -18,7 +20,7 @@ const convertContactsAsCiphers = async (
   cipherService: CipherService,
   cryptoService: CryptoService,
   i18nService: I18nService,
-  contacts: any
+  contacts: IOCozyContact[]
 ): Promise<CipherData[]> => {
   const contactsCiphers = [];
 

--- a/libs/cozy/contactCipher.ts
+++ b/libs/cozy/contactCipher.ts
@@ -6,10 +6,9 @@ import { PlatformUtilsService } from "@bitwarden/common/abstractions/platformUti
 import { StateService } from "@bitwarden/common/abstractions/state.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
-import { CipherResponse } from "@bitwarden/common/vault/models/response/cipher.response";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
-import { convertContactToCipherResponse } from "./contact.helper";
+import { convertContactToCipherData } from "./contact.helper";
 import { fetchContacts, fetchContact } from "./queries";
 
 const convertContactsAsCiphers = async (
@@ -17,21 +16,16 @@ const convertContactsAsCiphers = async (
   cryptoService: CryptoService,
   i18nService: any,
   contacts: any
-): Promise<CipherResponse[]> => {
+): Promise<CipherData[]> => {
   const contactsCiphers = [];
 
   const key = await cryptoService.getKeyForUserEncryption();
 
   for (const contact of contacts) {
     try {
-      const cipherResponse = await convertContactToCipherResponse(
-        cipherService,
-        i18nService,
-        contact,
-        key
-      );
+      const cipherData = await convertContactToCipherData(cipherService, i18nService, contact, key);
 
-      contactsCiphers.push(cipherResponse);
+      contactsCiphers.push(cipherData);
     } catch (e) {
       console.log(`Error during conversion of contact ${contact.id}`, contact, e);
     }
@@ -45,7 +39,7 @@ export const fetchContactsAndConvertAsCiphers = async (
   cryptoService: CryptoService,
   cozyClientService: any,
   i18nService: any
-): Promise<CipherResponse[]> => {
+): Promise<CipherData[]> => {
   const client = await cozyClientService.getClientInstance();
 
   try {
@@ -86,15 +80,9 @@ export const favoriteContactCipher = async (
     },
   });
 
-  const cipherResponse = await convertContactToCipherResponse(
-    cipherService,
-    i18nService,
-    updatedContact
-  );
+  const cipherData = await convertContactToCipherData(cipherService, i18nService, updatedContact);
 
-  const cipherData = new CipherData(cipherResponse);
-
-  await cipherService.upsert([cipherData]);
+  await cipherService.upsert(cipherData);
 
   return true;
 };

--- a/libs/cozy/fields.helper.ts
+++ b/libs/cozy/fields.helper.ts
@@ -1,4 +1,5 @@
 import { models } from "cozy-client";
+import { IOCozyContact } from "cozy-client/types/types";
 
 import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { FieldSubType } from "@bitwarden/common/enums/fieldSubType";
@@ -214,7 +215,10 @@ const buildFieldsFromContactByBrowsingModels = ({
   });
 };
 
-export const buildFieldsFromContact = (i18nService: I18nService, contact: any): FieldView[] => {
+export const buildFieldsFromContact = (
+  i18nService: I18nService,
+  contact: IOCozyContact
+): FieldView[] => {
   const builtFields: FieldView[] = [];
 
   const lang = i18nService.translationLocale;

--- a/libs/cozy/fields.helper.ts
+++ b/libs/cozy/fields.helper.ts
@@ -1,5 +1,6 @@
 import { models } from "cozy-client";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { FieldSubType } from "@bitwarden/common/enums/fieldSubType";
 import { FieldType } from "@bitwarden/common/enums/fieldType";
 import { ExpirationDateData } from "@bitwarden/common/vault/models/data/expiration-date.data";
@@ -52,7 +53,7 @@ export const buildField = (name: string, value: string, options: FieldOptions = 
 
 // Paper fields
 
-export const buildFieldsFromPaper = (i18nService: any, paper: any): FieldView[] => {
+export const buildFieldsFromPaper = (i18nService: I18nService, paper: any): FieldView[] => {
   const fields: FieldView[] = [];
 
   const qualificationLabels = formatMetadataQualification(paper.metadata);
@@ -213,7 +214,7 @@ const buildFieldsFromContactByBrowsingModels = ({
   });
 };
 
-export const buildFieldsFromContact = (i18nService: any, contact: any): FieldView[] => {
+export const buildFieldsFromContact = (i18nService: I18nService, contact: any): FieldView[] => {
   const builtFields: FieldView[] = [];
 
   const lang = i18nService.translationLocale;

--- a/libs/cozy/fields.helper.ts
+++ b/libs/cozy/fields.helper.ts
@@ -2,10 +2,8 @@ import { models } from "cozy-client";
 
 import { FieldSubType } from "@bitwarden/common/enums/fieldSubType";
 import { FieldType } from "@bitwarden/common/enums/fieldType";
-import { FieldApi } from "@bitwarden/common/models/api/field.api";
 import { ExpirationDateData } from "@bitwarden/common/vault/models/data/expiration-date.data";
 import { LabelData } from "@bitwarden/common/vault/models/data/label.data";
-import { Field } from "@bitwarden/common/vault/models/domain/field";
 import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
 
 import {
@@ -50,27 +48,6 @@ export const buildField = (name: string, value: string, options: FieldOptions = 
   field.name = name;
   field.value = value;
   return field;
-};
-
-export const copyEncryptedFields = (fields: Field[]): FieldApi[] => {
-  const encryptedFields = [];
-
-  for (const field of fields) {
-    encryptedFields.push(
-      new FieldApi({
-        Id: field.id,
-        ParentId: field.parentId,
-        Type: field.type,
-        Subtype: field.subtype,
-        ExpirationData: field.expirationData,
-        Label: field.label,
-        Name: field.name?.encryptedString || "",
-        Value: field.value?.encryptedString || "",
-      })
-    );
-  }
-
-  return encryptedFields;
 };
 
 // Paper fields

--- a/libs/cozy/note.helper.ts
+++ b/libs/cozy/note.helper.ts
@@ -2,8 +2,10 @@ import CozyClient from "cozy-client/types/CozyClient";
 import { Node, Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PaperType } from "@bitwarden/common/enums/paperType";
 import { SymmetricCryptoKey } from "@bitwarden/common/models/domain/symmetric-crypto-key";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -52,8 +54,8 @@ export const noteToText = (note: any): string => {
   return textOnly;
 };
 export const convertNoteToCipherData = async (
-  cipherService: any,
-  i18nService: any,
+  cipherService: CipherService,
+  i18nService: I18nService,
   paper: any,
   options: NoteConversionOptions,
   key?: SymmetricCryptoKey

--- a/libs/cozy/paper.helper.ts
+++ b/libs/cozy/paper.helper.ts
@@ -1,5 +1,7 @@
+import { I18nService } from "@bitwarden/common/abstractions/i18n.service";
 import { PaperType } from "@bitwarden/common/enums/paperType";
 import { SymmetricCryptoKey } from "@bitwarden/common/models/domain/symmetric-crypto-key";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -13,7 +15,7 @@ interface PaperConversionOptions {
 
 const DEFAULT_THUMBNAIL_URL = "/popup/images/icon-file-type-text.svg";
 
-const buildOwnerName = (i18nService: any, paper: any) => {
+const buildOwnerName = (i18nService: I18nService, paper: any) => {
   if (paper.contacts.data[0]?.displayName) {
     return paper.contacts.data[0]?.displayName;
   } else if (paper.cozyMetadata.createdByApp && paper.cozyMetadata.sourceAccountIdentifier) {
@@ -36,8 +38,8 @@ export const buildIllustrationUrl = (paper: any, baseUrl: string) => {
 };
 
 export const convertPaperToCipherData = async (
-  cipherService: any,
-  i18nService: any,
+  cipherService: CipherService,
+  i18nService: I18nService,
   paper: any,
   options: PaperConversionOptions,
   key?: SymmetricCryptoKey

--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -11,14 +11,16 @@ import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import { CozyClientService } from "../../apps/browser/src/popup/services/cozyClient.service";
+
 import { convertNoteToCipherData, isNote, fetchNoteIllustrationUrl } from "./note.helper";
 import { convertPaperToCipherData } from "./paper.helper";
 import { fetchPapers, fetchPaper } from "./queries";
 
 export const convertPapersAsCiphers = async (
-  cipherService: any,
+  cipherService: CipherService,
   cryptoService: CryptoService,
-  i18nService: any,
+  i18nService: I18nService,
   client: CozyClient,
   papers: any
 ): Promise<CipherData[]> => {
@@ -31,7 +33,7 @@ export const convertPapersAsCiphers = async (
   const key = await cryptoService.getKeyForUserEncryption();
 
   for (const paper of papers) {
-    let cipherData: CipherData;
+    let cipherData;
     try {
       if (isNote(paper)) {
         cipherData = await convertNoteToCipherData(
@@ -69,10 +71,10 @@ export const convertPapersAsCiphers = async (
 };
 
 export const fetchPapersAndConvertAsCiphers = async (
-  cipherService: any,
+  cipherService: CipherService,
   cryptoService: CryptoService,
-  cozyClientService: any,
-  i18nService: any
+  cozyClientService: CozyClientService,
+  i18nService: I18nService
 ): Promise<CipherData[]> => {
   const client = await cozyClientService.getClientInstance();
 
@@ -95,8 +97,8 @@ export const fetchPapersAndConvertAsCiphers = async (
     );
 
     return (await cipherService.getAll())
-      .filter((cipher: any) => cipher.type === CipherType.Paper)
-      .map((cipher: any) => cipher.toCipherData());
+      .filter((cipher) => cipher.type === CipherType.Paper)
+      .map((cipher) => cipher.toCipherData());
   }
 };
 
@@ -104,7 +106,7 @@ export const favoritePaperCipher = async (
   cipherService: CipherService,
   i18nService: I18nService,
   cipher: CipherView,
-  cozyClientService: any
+  cozyClientService: CozyClientService
 ): Promise<boolean> => {
   const client = await cozyClientService.getClientInstance();
 
@@ -140,7 +142,7 @@ export const deletePaperCipher = async (
   platformUtilsService: PlatformUtilsService,
   cipher: CipherView,
   stateService: StateService,
-  cozyClientService: any
+  cozyClientService: CozyClientService
 ): Promise<boolean> => {
   const confirmed = await platformUtilsService.showDialog(
     i18nService.t("deletePaperItemConfirmation"),

--- a/libs/cozy/queries.ts
+++ b/libs/cozy/queries.ts
@@ -1,5 +1,6 @@
 import { Q } from "cozy-client";
 import CozyClient from "cozy-client/types/CozyClient";
+import { IOCozyContact } from "cozy-client/types/types";
 
 const buildFilesQueryWithQualificationLabel = () => {
   const select = [
@@ -106,16 +107,19 @@ export const buildContactsQuery = () => ({
   },
 });
 
-export const fetchContacts = async (client: CozyClient) => {
+export const fetchContacts = async (client: CozyClient): Promise<IOCozyContact[]> => {
   const contactsQuery = buildContactsQuery();
 
-  const data = await client.queryAll(contactsQuery.definition, contactsQuery.options);
+  const data: IOCozyContact[] = await client.queryAll(
+    contactsQuery.definition,
+    contactsQuery.options
+  );
 
   return data;
 };
 
-export const fetchContact = async (client: CozyClient, _id: string) => {
-  const { data } = await client.query(Q("io.cozy.contacts").getById(_id));
+export const fetchContact = async (client: CozyClient, _id: string): Promise<IOCozyContact> => {
+  const { data }: { data: IOCozyContact } = await client.query(Q("io.cozy.contacts").getById(_id));
 
   return data;
 };


### PR DESCRIPTION
We were converting papers/contacts to CipherResponse because it is the model used by default during the sync.

Here we choose to convert to CipherData instead because :
- it help us add a fallback to the sync. When papers/contacts sync fail, we use the previous papers/contacts stored locally (they are stored as CipherData)
- the conversion is simplier (it involves less classes)
- we can still inject our papers/contacts during the sync thanks to the upsert method