### PR TITLE
[VER-446] fix: Correctly logout OAuth client on logout notification

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -830,6 +830,11 @@ export default class MainBackground {
     }
     //*/
 
+    // Cozy customization, logout OAuth client
+    //*
+    await this.cozyClientService.logout();
+    //*/
+
     await Promise.all([
       this.syncService.setLastSync(new Date(0), userId),
       this.cryptoService.clearKeys(userId),

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -143,7 +143,6 @@ export default class RuntimeBackground {
         break;
       case "logout":
         // 1- logout
-        await this.cozyClientService.logout();
         await this.main.logout(msg.expired, msg.userId);
         // 2- ask all frames of all tabs to activate login-in-page-menu
         for (const tab of await BrowserApi.getAllTabs()) {


### PR DESCRIPTION
When doing a logout we wan't the extension to also logout the Cozy's Oauth client

This was done from the `runtime.background.ts` file so the action is done when the user clicks on the Settings logout button

But this is not the only scenario that can produce a logout

This is the case when the user changes their password from cozy-settings. In that scenario, the cozy-stack will send a `logout` notification to the Bitwarden's realtime stream, and so the extension will react by doing a logout

To have the OAuth logout on both scenario we want to move the related code into `main.background.ts`