### PR TITLE
[VER-507] fix: Correctly display Konnectors icons after closing/reopenning the extension's popup

### DIFF
--- a/apps/browser/src/models/account.ts
+++ b/apps/browser/src/models/account.ts
@@ -8,7 +8,6 @@ import {
 import { BrowserComponentState } from "./browserComponentState";
 import { BrowserGroupingsComponentState } from "./browserGroupingsComponentState";
 import { BrowserSendComponentState } from "./browserSendComponentState";
-import { KonnectorsOrg } from "./konnectorsOrganization";
 
 export class AccountSettings extends BaseAccountSettings {
   vaultTimeout = -1; // On Restart
@@ -29,7 +28,7 @@ export class Account extends BaseAccount {
   ciphers?: BrowserComponentState;
   sendType?: BrowserComponentState;
   history?: string;
-  konnectorsOrganization?: KonnectorsOrg;
+  konnectorsOrganization?: string;
   bannerClosedByUser?: boolean;
 
   constructor(init: Partial<Account>) {

--- a/apps/browser/src/services/browser-state.service.ts
+++ b/apps/browser/src/services/browser-state.service.ts
@@ -197,7 +197,10 @@ export class BrowserStateService
   }
 
   async getKonnectorsOrganization(): Promise<KonnectorsOrg> {
-    return (await this.getAccount(await this.defaultInMemoryOptions()))?.konnectorsOrganization;
+    const organizationString = (await this.getAccount(await this.defaultInMemoryOptions()))
+      ?.konnectorsOrganization;
+
+    return organizationString ? JSON.parse(organizationString) : null;
   }
 
   async setKonnectorsOrganization(value: KonnectorsOrg): Promise<void> {
@@ -205,7 +208,7 @@ export class BrowserStateService
     if (!account) {
       return;
     }
-    account.konnectorsOrganization = value;
+    account.konnectorsOrganization = JSON.stringify(value);
     await this.saveAccount(account, await this.defaultInMemoryOptions());
   }
 

--- a/apps/browser/src/vault/popup/components/cipher-row.component.ts
+++ b/apps/browser/src/vault/popup/components/cipher-row.component.ts
@@ -1,7 +1,7 @@
 /* Cozy custo
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 */
-import { Component, EventEmitter, Input, Output, OnInit } from "@angular/core";
+import { Component, EventEmitter, Input, Output, OnChanges } from "@angular/core";
 /* end custo */
 
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -19,7 +19,7 @@ import { DomSanitizer } from "@angular/platform-browser";
   selector: "app-cipher-row",
   templateUrl: "cipher-row.component.html",
 })
-export class CipherRowComponent implements OnInit {
+export class CipherRowComponent implements OnChanges {
   @Output() onSelected = new EventEmitter<CipherView>();
   @Output() launchEvent = new EventEmitter<CipherView>();
   @Output() onView = new EventEmitter<CipherView>();
@@ -89,7 +89,7 @@ export class CipherRowComponent implements OnInit {
   // Cozy customization end
 
   // Cozy customization, differentiate shared Ciphers from ciphers in "Cozy Connectors" organization
-  async ngOnInit() {
+  async ngOnChanges() {
     if (this.cipher.organizationId) {
       this.isKonnector = await this.konnectorService.isKonnectorsOrganization(
         this.cipher.organizationId


### PR DESCRIPTION
KonnectorsOrganization is currently saved in the account InMemory storage as an object

We found that this may produce DeadObjects errors on Firefox due to the way it manage memory

Exemple scenario for reproducing this problem: open the Cozy Connectors folder, close the extension popup and re-open it. The ciphers will lose their "shared with Cozy" icons and the `can’t access dead object` error should appear in the devtools

We found that storing the info in the account as a string instead of an object would prevent the issue to happen

We could have also use `defaultOnDiskOptions` instead of `defaultInMemoryOptions` to save the `KonnectorsOrganization` data, but the string option seems to have less possible side effects

Related link:
https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/
