### PR TITLE
[VER-507] fix: Display shared icon on cipher row even when no subtitle

### DIFF
--- a/apps/browser/src/vault/popup/components/cipher-row.component.html
+++ b/apps/browser/src/vault/popup/components/cipher-row.component.html
@@ -80,7 +80,10 @@
         <span class="detail">{{ getSubtitle(cipher) }}</span>
         -->
         <!---->
-        <span class="detail no-white-space" *ngIf="getSubtitle(cipher)">
+        <span
+          class="detail no-white-space"
+          *ngIf="getSubtitle(cipher) || (cipher.organizationId && !isKonnector)"
+        >
           <i
             *ngIf="cipher.organizationId && !isKonnector"
             class="icon-cozy icon-cozy-details icon-share"


### PR DESCRIPTION
In previous commit we moved the `shared` icon on the cipher row's details line

This line is displayed only when the cipher has a subtitle, so if a cipher is shared but has no subtitle, then the `shared` icon will not be displayed

This commit fix this by displaying the detail line if the cipher has a subtitle OR if it is shared

This may produce a weird display but the case is rare enough to be problematic

### Before (this is a folder view so every cipher are shared in it):
![image](https://github.com/cozy/cozy-keys-browser/assets/1884255/35bb57ea-8d4a-4f1b-b36d-d87a10f77281)

### After:
![image](https://github.com/cozy/cozy-keys-browser/assets/1884255/2ae06828-318f-4888-a8f1-3726267be928)
