### PR TITLE
Fix blinking thumbnail row

### DIFF
--- a/apps/browser/src/popup/scss/misc.scss
+++ b/apps/browser/src/popup/scss/misc.scss
@@ -433,10 +433,6 @@ li.active .icon-cozy-inline > svg {
   max-height: 26px !important;
 }
 
-.icon-paper-wrapper::before {
-  content: url("../images/icon-file-type-text.png");
-}
-
 .cipher-illustration {
   display: flex;
   justify-content: center;

--- a/apps/browser/src/vault/popup/components/cipher-row.component.ts
+++ b/apps/browser/src/vault/popup/components/cipher-row.component.ts
@@ -84,6 +84,10 @@ export class CipherRowComponent implements OnInit {
     // A thumbnail URL is valid for 10 minutes. If a thumbnail URL is expired,
     // it is very likely that all thumbnail URLs are expired. So we start a
     // full sync that will get new thumbnail URLs.
+    // We also change directly the thumbnail URL with the default one and
+    // when the sync will be done, a new cipher row will be created with
+    // a new thumbnail URL.
+    this.cipher.paper.illustrationThumbnailUrl = "/popup/images/icon-file-type-text.png";
     await this.syncService.fullSync(true);
   }
   // Cozy customization end


### PR DESCRIPTION
When a thumbnail URL is invalid, it triggers the onThumbnailError handler and we display a default thumbnail in CSS. If the HTML view is reloaded (which happens a lot), it triggers again and again the onThumbnailError and the default thumbnail in CSS handler leading to a blinking thumbnail.

Now we change directly the thumbnail URL with the default one. So no onThumbnailError handler triggered. When the sync will be done, a new cipher row will a new thumbnail URL.