### PR TITLE
feat: Handle contacts in inPageMenu

### DIFF
--- a/apps/browser/src/autofill/content/menuCtrler.js
+++ b/apps/browser/src/autofill/content/menuCtrler.js
@@ -516,6 +516,9 @@ function getPossibleTypesForField(fieldEl) {
   if (fieldEl.fieldTypes.identity) {
     cipherTypes.push(CipherType.Identity);
   }
+  if (fieldEl.fieldTypes.contact) {
+    cipherTypes.push(CipherType.Contact);
+  }
 
   return cipherTypes;
 }
@@ -721,7 +724,7 @@ function _setApplyFadeInUrl(doApply, fieldTypes) {
   const url = new URL(menuEl.src);
   if (doApply) {
     fieldTypes = {
-      ...{ login: false, identity: false, card: false, fieldFormat: false },
+      ...{ login: false, identity: false, card: false, contact: false, fieldFormat: false },
       ...fieldTypes,
     };
     state.iFrameHash = { ...state.iFrameHash, ...fieldTypes, applyFadeIn: true };

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -15,7 +15,10 @@ import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view
 
 import { generateIdentityViewFromCipherView } from "../../../../../libs/cozy/contact.helper";
 import { BrowserApi } from "../../browser/browserApi";
-import { evaluateDecisionArray, makeDecisionArray } from "../../cozy/autofill/evaluateDecisionArray";
+import {
+  evaluateDecisionArray,
+  makeDecisionArray,
+} from "../../cozy/autofill/evaluateDecisionArray";
 import { BrowserStateService } from "../../services/abstractions/browser-state.service";
 import AutofillField from "../models/autofill-field";
 import AutofillPageDetails from "../models/autofill-page-details";
@@ -700,7 +703,7 @@ export default class AutofillService implements AutofillServiceInterface {
           break;
       }
 
-      const decisionArray = makeDecisionArray(scriptContext)
+      const decisionArray = makeDecisionArray(scriptContext);
       scriptContext.ambiguity = decisionArray.ambiguity;
       scriptContext.decisionArray = decisionArray;
     }

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -200,6 +200,7 @@ export default class RuntimeBackground {
               logins: logins,
               cards: [] as Array<CipherExport>,
               identities: [] as Array<CipherView>,
+              contacts: [] as Array<CipherView>,
             };
             for (const cipher of allCiphers) {
               if (cipher.isDeleted) {
@@ -213,6 +214,13 @@ export default class RuntimeBackground {
                   break;
                 case CipherType.Identity:
                   ciphers.identities.push(cipher);
+                  break;
+                case CipherType.Contact:
+                  if (cipher.contact.me) {
+                    ciphers.contacts.unshift(cipher);
+                  } else if (cipher.favorite) {
+                    ciphers.contacts.push(cipher);
+                  }
                   break;
               }
             }

--- a/apps/browser/src/cozy/autofill/evaluateDecisionArray.spec.ts
+++ b/apps/browser/src/cozy/autofill/evaluateDecisionArray.spec.ts
@@ -19,10 +19,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: true,
       hasCardCipher: true,
       hasIdentityCipher: true,
+      hasContactCipher: false,
       ambiguity: 1,
       loginFellows: 3,
       cardFellows: 3,
       identityFellows: 3,
+      contactFellows: 3,
       field_isInForm: true, // SET
       field_isInSearchForm: false, // SET
       field_isInloginForm: true,
@@ -41,10 +43,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: true,
       hasCardCipher: true,
       hasIdentityCipher: true,
+      hasContactCipher: false,
       ambiguity: 0,
       loginFellows: 0,
       cardFellows: 0,
       identityFellows: 0,
+      contactFellows: 0,
       field_isInForm: false,
       field_isInSearchForm: true, // SET
       field_isInloginForm: false,
@@ -63,11 +67,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: false,
       hasCardCipher: false,
       hasIdentityCipher: false,
+      hasContactCipher: false,
       ambiguity: 0,
       loginFellows: 2, // SET
       cardFellows: 0,
       identityFellows: 0,
-      field_isInForm: false,
+      contactFellows: 0,
       field_isInForm: false, // SET
       field_isInSearchForm: false,
       field_isInloginForm: false,
@@ -86,10 +91,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: false,
       hasCardCipher: false,
       hasIdentityCipher: false,
+      hasContactCipher: false,
       ambiguity: 1, // SET
       loginFellows: 0,
       cardFellows: 2, // SET
       identityFellows: 0,
+      contactFellows: 0,
       field_isInForm: true, // SET
       field_isInSearchForm: false,
       field_isInloginForm: false,
@@ -113,10 +120,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: false,
       hasCardCipher: false,
       hasIdentityCipher: false,
+      hasContactCipher: false,
       ambiguity: 0, // SET
       loginFellows: 0,
       cardFellows: 4, // SET
       identityFellows: 0,
+      contactFellows: 0,
       field_isInForm: true, // SET
       field_isInSearchForm: false,
       field_isInloginForm: false,
@@ -140,10 +149,37 @@ describe("Autofill Service", () => {
       hasLoginCipher: false,
       hasCardCipher: false,
       hasIdentityCipher: true, // SET
+      hasContactCipher: false,
       ambiguity: 0,
       loginFellows: 0,
       cardFellows: 0,
       identityFellows: 2, // SET
+      contactFellows: 0,
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true, // SET
+      field_viewable: false,
+    }
+
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in, there are at least 2 Contacts fields, we are in a form => We should display menu (i.e. EDF account creation)", () => {
+    const decisionArray: DecisionArray = {
+      connected: true, // SET
+      hasExistingCipher: false,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      hasContactCipher: true, // SET
+      ambiguity: 0,
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 0,
+      contactFellows: 2, // SET
       field_isInForm: true, // SET
       field_isInSearchForm: false,
       field_isInloginForm: false,
@@ -163,10 +199,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: true, // SET
       hasCardCipher: false,
       hasIdentityCipher: false,
+      hasContactCipher: false,
       ambiguity: 0,
       loginFellows: 2, // SET
       cardFellows: 0,
       identityFellows: 0,
+      contactFellows: 0,
       field_isInForm: true, // VARY
       field_isInSearchForm: false,
       field_isInloginForm: true, // SET
@@ -190,10 +228,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: true, // SET
       hasCardCipher: false,
       hasIdentityCipher: false,
+      hasContactCipher: false,
       ambiguity: 0,
       loginFellows: 2, // SET
       cardFellows: 0,
       identityFellows: 0,
+      contactFellows: 0,
       field_isInForm: true,
       field_isInSearchForm: false,
       field_isInloginForm: false,
@@ -213,10 +253,41 @@ describe("Autofill Service", () => {
       hasLoginCipher: false,
       hasCardCipher: false,
       hasIdentityCipher: true,
+      hasContactCipher: false,
       ambiguity: 0, // SET
       loginFellows: 0,
       cardFellows: 0,
       identityFellows: 1, // SET
+      contactFellows: 0,
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    decisionArray.connected = true
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+    
+    decisionArray.connected = false
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in (or not), no ambiguity, there are at least 2 Contacts fields => We should display menu (i.e. Netflix)", () => {
+    const decisionArray: DecisionArray = {
+      connected: false, // VARY
+      hasExistingCipher: false,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      hasContactCipher: true,
+      ambiguity: 0, // SET
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 0,
+      contactFellows: 1, // SET
       field_isInForm: true, // SET
       field_isInSearchForm: false,
       field_isInloginForm: false,
@@ -240,10 +311,41 @@ describe("Autofill Service", () => {
       hasLoginCipher: false,
       hasCardCipher: false,
       hasIdentityCipher: true,
+      hasContactCipher: false,
       ambiguity: 1, // SET
       loginFellows: 0,
       cardFellows: 0,
       identityFellows: 2, // SET
+      contactFellows: 0,
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    decisionArray.connected = true
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+    
+    decisionArray.connected = false
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in (or not), with ambiguity, there are at least 3 Identiy fields => We should display menu (i.e. CCM)", () => {
+    const decisionArray: DecisionArray = {
+      connected: false, // VARY
+      hasExistingCipher: false,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      hasContactCipher: true,
+      ambiguity: 1, // SET
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 0,
+      contactFellows: 2, // SET
       field_isInForm: true, // SET
       field_isInSearchForm: false,
       field_isInloginForm: false,
@@ -267,10 +369,12 @@ describe("Autofill Service", () => {
       hasLoginCipher: true, // SET
       hasCardCipher: false,
       hasIdentityCipher: true,
+      hasContactCipher: false,
       ambiguity: 0,
       loginFellows: 0,
       cardFellows: 0,
       identityFellows: 0,
+      contactFellows: 0,
       field_isInForm: false,
       field_isInSearchForm: false,
       field_isInloginForm: false,

--- a/apps/browser/src/cozy/autofill/evaluateDecisionArray.spec.ts
+++ b/apps/browser/src/cozy/autofill/evaluateDecisionArray.spec.ts
@@ -1,0 +1,286 @@
+import { DecisionArray, evaluateDecisionArray } from "./evaluateDecisionArray"
+
+const makeAction = (decisionArray: DecisionArray) => {
+  return [
+    null,
+    null,
+    null,
+    {
+      decisionArray
+    }
+  ]
+}
+
+describe("Autofill Service", () => {
+  it("Extension is logged in, has an existing cipher for website, we are in a form that's not a search => We should display the menu (e.g. assurance retraite)", () => {
+    const decisionArray: DecisionArray = {
+      connected: true, // SET
+      hasExistingCipher: true, // SET
+      hasLoginCipher: true,
+      hasCardCipher: true,
+      hasIdentityCipher: true,
+      ambiguity: 1,
+      loginFellows: 3,
+      cardFellows: 3,
+      identityFellows: 3,
+      field_isInForm: true, // SET
+      field_isInSearchForm: false, // SET
+      field_isInloginForm: true,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: true, 
+    }
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("We are in a search form => We should never display the menu", () => {
+    const decisionArray: DecisionArray = {
+      connected: true,
+      hasExistingCipher: true,
+      hasLoginCipher: true,
+      hasCardCipher: true,
+      hasIdentityCipher: true,
+      ambiguity: 0,
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 0,
+      field_isInForm: false,
+      field_isInSearchForm: true, // SET
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: true,
+      field_visible: true,
+      field_viewable: true, 
+    }
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(false)
+  })
+
+  it("Extension is logged in, has an existing cipher for website, we are NOT in a form but there are at least 2 Login fields => We should display menu (e.g. EDF)", () => {
+    const decisionArray: DecisionArray = {
+      connected: true, // SET
+      hasExistingCipher: true, // SET
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      ambiguity: 0,
+      loginFellows: 2, // SET
+      cardFellows: 0,
+      identityFellows: 0,
+      field_isInForm: false,
+      field_isInForm: false, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true, // SET
+      field_viewable: false,
+    }
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in (or not), no ambiguity, there are at least 2 Card fields, we are in a form => We should display menu", () => {
+    const decisionArray: DecisionArray = {
+      connected: true, // VARY
+      hasExistingCipher: true,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      ambiguity: 1, // SET
+      loginFellows: 0,
+      cardFellows: 2, // SET
+      identityFellows: 0,
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    decisionArray.connected = true
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+    
+    decisionArray.connected = false
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in (or not), ambiguity, but there are at least 4 Card fields, we are in a form => We should display menu", () => {
+    const decisionArray: DecisionArray = {
+      connected: true, // VARY
+      hasExistingCipher: true,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      ambiguity: 0, // SET
+      loginFellows: 0,
+      cardFellows: 4, // SET
+      identityFellows: 0,
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    decisionArray.connected = true
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+    
+    decisionArray.connected = false
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in, there are at least 2 Identity fields, we are in a form => We should display menu (i.e. EDF account creation)", () => {
+    const decisionArray: DecisionArray = {
+      connected: true, // SET
+      hasExistingCipher: false,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: true, // SET
+      ambiguity: 0,
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 2, // SET
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true, // SET
+      field_viewable: false,
+    }
+
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged out, enough Login fields, we are in a login form (or not) => We should display the menu (i.e. login Cozy or Fnac)", () => {
+    const decisionArray: DecisionArray = {
+      connected: false, // SET
+      hasExistingCipher: false,
+      hasLoginCipher: true, // SET
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      ambiguity: 0,
+      loginFellows: 2, // SET
+      cardFellows: 0,
+      identityFellows: 0,
+      field_isInForm: true, // VARY
+      field_isInSearchForm: false,
+      field_isInloginForm: true, // SET
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    decisionArray.field_isInForm = true
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+    
+    decisionArray.field_isInForm = false
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged out, there is a generic login, we are in a signup form => We should display the menu (i.e. signup form CCM)", () => {
+    const decisionArray: DecisionArray = {
+      connected: false, // SET
+      hasExistingCipher: false,
+      hasLoginCipher: true, // SET
+      hasCardCipher: false,
+      hasIdentityCipher: false,
+      ambiguity: 0,
+      loginFellows: 2, // SET
+      cardFellows: 0,
+      identityFellows: 0,
+      field_isInForm: true,
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: true, // SET
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in (or not), no ambiguity, there are at least 2 Identiy fields => We should display menu (i.e. Netflix)", () => {
+    const decisionArray: DecisionArray = {
+      connected: false, // VARY
+      hasExistingCipher: false,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: true,
+      ambiguity: 0, // SET
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 1, // SET
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    decisionArray.connected = true
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+    
+    decisionArray.connected = false
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Extension is logged in (or not), with ambiguity, there are at least 3 Identiy fields => We should display menu (i.e. CCM)", () => {
+    const decisionArray: DecisionArray = {
+      connected: false, // VARY
+      hasExistingCipher: false,
+      hasLoginCipher: false,
+      hasCardCipher: false,
+      hasIdentityCipher: true,
+      ambiguity: 1, // SET
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 2, // SET
+      field_isInForm: true, // SET
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    decisionArray.connected = true
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+    
+    decisionArray.connected = false
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
+  })
+
+  it("Logged in, no existing cipher, a login field => We should NOT display menu (i.e. trainline)", () => {
+    const decisionArray: DecisionArray = {
+      connected: true, // SET
+      hasExistingCipher: false, // SET
+      hasLoginCipher: true, // SET
+      hasCardCipher: false,
+      hasIdentityCipher: true,
+      ambiguity: 0,
+      loginFellows: 0,
+      cardFellows: 0,
+      identityFellows: 0,
+      field_isInForm: false,
+      field_isInSearchForm: false,
+      field_isInloginForm: false,
+      field_isInSignupForm: false,
+      hasMultipleScript: false,
+      field_visible: true,
+      field_viewable: false,
+    }
+
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(false)
+  
+  })
+})

--- a/apps/browser/src/cozy/autofill/evaluateDecisionArray.spec.ts
+++ b/apps/browser/src/cozy/autofill/evaluateDecisionArray.spec.ts
@@ -1,4 +1,4 @@
-import { DecisionArray, evaluateDecisionArray } from "./evaluateDecisionArray"
+import { DecisionArray, evaluateDecisionArray } from "./evaluateDecisionArray";
 
 const makeAction = (decisionArray: DecisionArray) => {
   return [
@@ -6,10 +6,10 @@ const makeAction = (decisionArray: DecisionArray) => {
     null,
     null,
     {
-      decisionArray
-    }
-  ]
-}
+      decisionArray,
+    },
+  ];
+};
 
 describe("Autofill Service", () => {
   it("Extension is logged in, has an existing cipher for website, we are in a form that's not a search => We should display the menu (e.g. assurance retraite)", () => {
@@ -31,10 +31,10 @@ describe("Autofill Service", () => {
       field_isInSignupForm: false,
       hasMultipleScript: false,
       field_visible: true,
-      field_viewable: true, 
-    }
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+      field_viewable: true,
+    };
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("We are in a search form => We should never display the menu", () => {
     const decisionArray: DecisionArray = {
@@ -55,10 +55,10 @@ describe("Autofill Service", () => {
       field_isInSignupForm: false,
       hasMultipleScript: true,
       field_visible: true,
-      field_viewable: true, 
-    }
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(false)
-  })
+      field_viewable: true,
+    };
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(false);
+  });
 
   it("Extension is logged in, has an existing cipher for website, we are NOT in a form but there are at least 2 Login fields => We should display menu (e.g. EDF)", () => {
     const decisionArray: DecisionArray = {
@@ -80,9 +80,9 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true, // SET
       field_viewable: false,
-    }
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    };
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in (or not), no ambiguity, there are at least 2 Card fields, we are in a form => We should display menu", () => {
     const decisionArray: DecisionArray = {
@@ -104,14 +104,14 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    decisionArray.connected = true
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-    
-    decisionArray.connected = false
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    decisionArray.connected = true;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+
+    decisionArray.connected = false;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in (or not), ambiguity, but there are at least 4 Card fields, we are in a form => We should display menu", () => {
     const decisionArray: DecisionArray = {
@@ -133,14 +133,14 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    decisionArray.connected = true
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-    
-    decisionArray.connected = false
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    decisionArray.connected = true;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+
+    decisionArray.connected = false;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in, there are at least 2 Identity fields, we are in a form => We should display menu (i.e. EDF account creation)", () => {
     const decisionArray: DecisionArray = {
@@ -162,10 +162,10 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true, // SET
       field_viewable: false,
-    }
+    };
 
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in, there are at least 2 Contacts fields, we are in a form => We should display menu (i.e. EDF account creation)", () => {
     const decisionArray: DecisionArray = {
@@ -187,10 +187,10 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true, // SET
       field_viewable: false,
-    }
+    };
 
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged out, enough Login fields, we are in a login form (or not) => We should display the menu (i.e. login Cozy or Fnac)", () => {
     const decisionArray: DecisionArray = {
@@ -212,14 +212,14 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    decisionArray.field_isInForm = true
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-    
-    decisionArray.field_isInForm = false
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    decisionArray.field_isInForm = true;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+
+    decisionArray.field_isInForm = false;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged out, there is a generic login, we are in a signup form => We should display the menu (i.e. signup form CCM)", () => {
     const decisionArray: DecisionArray = {
@@ -241,10 +241,10 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in (or not), no ambiguity, there are at least 2 Identiy fields => We should display menu (i.e. Netflix)", () => {
     const decisionArray: DecisionArray = {
@@ -266,14 +266,14 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    decisionArray.connected = true
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-    
-    decisionArray.connected = false
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    decisionArray.connected = true;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+
+    decisionArray.connected = false;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in (or not), no ambiguity, there are at least 2 Contacts fields => We should display menu (i.e. Netflix)", () => {
     const decisionArray: DecisionArray = {
@@ -295,14 +295,14 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    decisionArray.connected = true
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-    
-    decisionArray.connected = false
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    decisionArray.connected = true;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+
+    decisionArray.connected = false;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in (or not), with ambiguity, there are at least 3 Identiy fields => We should display menu (i.e. CCM)", () => {
     const decisionArray: DecisionArray = {
@@ -324,14 +324,14 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    decisionArray.connected = true
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-    
-    decisionArray.connected = false
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    decisionArray.connected = true;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+
+    decisionArray.connected = false;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Extension is logged in (or not), with ambiguity, there are at least 3 Identiy fields => We should display menu (i.e. CCM)", () => {
     const decisionArray: DecisionArray = {
@@ -353,14 +353,14 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    decisionArray.connected = true
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-    
-    decisionArray.connected = false
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true)
-  })
+    decisionArray.connected = true;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+
+    decisionArray.connected = false;
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(true);
+  });
 
   it("Logged in, no existing cipher, a login field => We should NOT display menu (i.e. trainline)", () => {
     const decisionArray: DecisionArray = {
@@ -382,9 +382,8 @@ describe("Autofill Service", () => {
       hasMultipleScript: false,
       field_visible: true,
       field_viewable: false,
-    }
+    };
 
-    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(false)
-  
-  })
-})
+    expect(evaluateDecisionArray(makeAction(decisionArray))).toBe(false);
+  });
+});

--- a/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
+++ b/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
@@ -170,7 +170,10 @@
     hasIdentityCipher: boolean
     /** The field corresponds to at least 1 field of a generic Contact cipher */
     hasContactCipher: boolean
-    /** Ambiguity level, for now we handle 0 or 1 */
+    /** Sometimes 1 field is not enough to guess which types of cipher are eligibles
+     * For exemple, the field `email` is not enough to guess that we are in an Identity form or a Login form
+     * But if we have more related field like `firstName`, `phone` or `ssn`, then we can guess that it is an Identity form
+     * 1 if we accept that an anbiguous field triggers the corresponding type, 0 otherwise */
     ambiguity: number
     /** Number of fields in the page corresponding to a generic Login cipher */
     loginFellows: number

--- a/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
+++ b/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
@@ -1,0 +1,157 @@
+  const ATTRIBUTES_AMBIGUITY: any = {
+    identity: {
+      title: 1,
+      firstName: 1,
+      middleName: 1,
+      lastName: 1,
+      address1: 1,
+      address2: 1,
+      address3: 1,
+      city: 1,
+      state: 1,
+      postalCode: 1,
+      country: 1,
+      company: 1,
+      email: 0,
+      phone: 0,
+      ssn: 0,
+      username: 1,
+      passportNumber: 1,
+      licenseNumber: 1,
+    },
+    card: {
+      cardholderName: 1,
+      brand: 1,
+      number: 1,
+      expMonth: 0,
+      expYear: 0,
+      code: 1,
+    },
+    login: {
+      uris: 1,
+      username: 1,
+      password: 1,
+      passwordRevisionDate: 1,
+      totp: 1,
+    }
+  };
+
+  export const makeDecisionArray = (scriptContext: any): DecisionArray => {
+    // check if the field is associated to an ambiguous attribute of a cipher
+    const ambiguity = ATTRIBUTES_AMBIGUITY[scriptContext.cipher.type][scriptContext.cipher.fieldType] ?? 0;
+    // prepare decision array used to decide if the script should be run for this field
+    const decisionArray: DecisionArray = {
+      connected: scriptContext.connected,
+      hasExistingCipher: scriptContext.hasExistingCipher,
+      hasLoginCipher: scriptContext.hasLoginCipher,
+      hasCardCipher: scriptContext.hasCardCipher,
+      hasIdentityCipher: scriptContext.hasIdentityCipher,
+      ambiguity: ambiguity,
+      loginFellows: scriptContext.loginFellows,
+      cardFellows: scriptContext.cardFellows,
+      identityFellows: scriptContext.identityFellows,
+      field_isInForm: scriptContext.field.isInForm,
+      field_isInSearchForm: scriptContext.field.isInSearchForm,
+      field_isInloginForm: scriptContext.field.isInloginForm,
+      field_isInSignupForm: scriptContext.field.isInSignupForm,
+      hasMultipleScript: scriptContext.hasMultipleScript,
+      field_visible: scriptContext.field.visible,
+      field_viewable: scriptContext.field.viewableOri, // use the original value
+    };
+
+    return decisionArray;
+  }
+  
+  /* -------------------------------------------------------------------------------- */
+  // Evaluate if a decision array is valid to activate a menu for the field in the page.
+  export const evaluateDecisionArray = (action: any) => {
+    const da = action[3].decisionArray as DecisionArray;
+    // selection conditions
+    if (
+      da.hasExistingCipher === true &&
+      da.field_isInForm === true &&
+      da.field_isInSearchForm === false
+    ) {
+      return true;
+    }
+    if (da.field_isInSearchForm === true) {
+      return false;
+    }
+    if (
+      da.connected === true &&
+      da.hasExistingCipher === true &&
+      da.loginFellows > 1 &&
+      da.field_visible === true
+    ) {
+      return true;
+    }
+    if (da.ambiguity === 1 && da.cardFellows > 1 && da.field_isInForm === true) {
+      return true;
+    }
+    if (da.ambiguity === 0 && da.cardFellows > 3 && da.field_isInForm === true) {
+      return true;
+    }
+    if (
+      da.connected === true &&
+      da.hasIdentityCipher === true &&
+      da.identityFellows > 1 &&
+      da.field_visible === true
+    ) {
+      return true;
+    }
+    if (da.connected === false && da.loginFellows === 2) {
+      return true;
+    }
+    if (da.connected === false && da.hasLoginCipher === true && da.field_isInloginForm === true) {
+      return true;
+    }
+    if (da.connected === false && da.hasLoginCipher === true && da.field_isInSignupForm === true) {
+      return true;
+    }
+    if (da.ambiguity === 0 && da.identityFellows > 0 && da.field_isInForm === true) {
+      return true;
+    }
+    if (da.ambiguity === 1 && da.identityFellows > 1 && da.field_isInForm === true) {
+      return true;
+    }
+    if (da.connected === true && da.hasExistingCipher === undefined && da.hasLoginCipher === true) {
+      return false;
+    }
+    // end selection conditions
+    return false;
+  }
+
+  export interface DecisionArray {
+    /** If the extension is logged in */
+    connected: boolean
+    /** At least one field in the page corresponds to a field in an existing cipher */
+    hasExistingCipher: boolean
+    /** The field corresponds to at least 1 field of a generic Login cipher */
+    hasLoginCipher: boolean
+    /** The field corresponds to at least 1 field of a generic Card cipher */
+    hasCardCipher: boolean
+    /** The field corresponds to at least 1 field of a generic Identity cipher */
+    hasIdentityCipher: boolean
+    /** Ambiguity level, for now we handle 0 or 1 */
+    ambiguity: number
+    /** Number of fields in the page corresponding to a generic Login cipher */
+    loginFellows: number
+    /** Number of fields in the page corresponding to a generic Card cipher */
+    cardFellows: number
+    /** Number of fields in the page corresponding to a generic Identity cipher */
+    identityFellows: number
+    /** If the field is inside a `<form>` element */
+    field_isInForm: boolean
+    /** If the field is inside a `<form>` element that contains search related terms (i.e. `search`, `recherche`) */
+    field_isInSearchForm: boolean
+    /** If the field is inside a `<form>` element that contains login related terms (i.e. `login`, `signin`) */
+    field_isInloginForm: boolean
+    /** If the field is inside a `<form>` element that contains signup related terms (i.e. `signup`, `register`) */
+    field_isInSignupForm: boolean
+    /** If the `<form>` has multiple fields with the same `fieldType` (i.e. `login_email`, `login_password`) */
+    hasMultipleScript: boolean
+    /** If none of the field's parents is `display=none` or `visibility=hidden` */
+    field_visible: boolean
+    /** If the field is visible AND the user doesn't have to scroll to have it displayed in the viewport */
+    field_viewable: boolean
+  }

--- a/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
+++ b/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
@@ -33,6 +33,26 @@
       password: 1,
       passwordRevisionDate: 1,
       totp: 1,
+    },
+    contact: {
+      title: 1,
+      firstName: 1,
+      middleName: 1,
+      lastName: 1,
+      address1: 1,
+      address2: 1,
+      address3: 1,
+      city: 1,
+      state: 1,
+      postalCode: 1,
+      country: 1,
+      company: 1,
+      email: 0,
+      phone: 0,
+      ssn: 0,
+      username: 1,
+      passportNumber: 1,
+      licenseNumber: 1,
     }
   };
 
@@ -46,10 +66,12 @@
       hasLoginCipher: scriptContext.hasLoginCipher,
       hasCardCipher: scriptContext.hasCardCipher,
       hasIdentityCipher: scriptContext.hasIdentityCipher,
+      hasContactCipher: scriptContext.hasContactCipher,
       ambiguity: ambiguity,
       loginFellows: scriptContext.loginFellows,
       cardFellows: scriptContext.cardFellows,
       identityFellows: scriptContext.identityFellows,
+      contactFellows: scriptContext.contactFellows,
       field_isInForm: scriptContext.field.isInForm,
       field_isInSearchForm: scriptContext.field.isInSearchForm,
       field_isInloginForm: scriptContext.field.isInloginForm,
@@ -99,6 +121,14 @@
     ) {
       return true;
     }
+    if (
+      da.connected === true &&
+      da.hasContactCipher === true &&
+      da.contactFellows > 1 &&
+      da.field_visible === true
+    ) {
+      return true;
+    }
     if (da.connected === false && da.loginFellows === 2) {
       return true;
     }
@@ -112,6 +142,12 @@
       return true;
     }
     if (da.ambiguity === 1 && da.identityFellows > 1 && da.field_isInForm === true) {
+      return true;
+    }
+    if (da.ambiguity === 0 && da.contactFellows > 0 && da.field_isInForm === true) {
+      return true;
+    }
+    if (da.ambiguity === 1 && da.contactFellows > 1 && da.field_isInForm === true) {
       return true;
     }
     if (da.connected === true && da.hasExistingCipher === undefined && da.hasLoginCipher === true) {
@@ -132,6 +168,8 @@
     hasCardCipher: boolean
     /** The field corresponds to at least 1 field of a generic Identity cipher */
     hasIdentityCipher: boolean
+    /** The field corresponds to at least 1 field of a generic Contact cipher */
+    hasContactCipher: boolean
     /** Ambiguity level, for now we handle 0 or 1 */
     ambiguity: number
     /** Number of fields in the page corresponding to a generic Login cipher */
@@ -140,6 +178,8 @@
     cardFellows: number
     /** Number of fields in the page corresponding to a generic Identity cipher */
     identityFellows: number
+    /** Number of fields in the page corresponding to a generic Contact cipher */
+    contactFellows: number
     /** If the field is inside a `<form>` element */
     field_isInForm: boolean
     /** If the field is inside a `<form>` element that contains search related terms (i.e. `search`, `recherche`) */

--- a/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
+++ b/apps/browser/src/cozy/autofill/evaluateDecisionArray.ts
@@ -1,200 +1,201 @@
-  const ATTRIBUTES_AMBIGUITY: any = {
-    identity: {
-      title: 1,
-      firstName: 1,
-      middleName: 1,
-      lastName: 1,
-      address1: 1,
-      address2: 1,
-      address3: 1,
-      city: 1,
-      state: 1,
-      postalCode: 1,
-      country: 1,
-      company: 1,
-      email: 0,
-      phone: 0,
-      ssn: 0,
-      username: 1,
-      passportNumber: 1,
-      licenseNumber: 1,
-    },
-    card: {
-      cardholderName: 1,
-      brand: 1,
-      number: 1,
-      expMonth: 0,
-      expYear: 0,
-      code: 1,
-    },
-    login: {
-      uris: 1,
-      username: 1,
-      password: 1,
-      passwordRevisionDate: 1,
-      totp: 1,
-    },
-    contact: {
-      title: 1,
-      firstName: 1,
-      middleName: 1,
-      lastName: 1,
-      address1: 1,
-      address2: 1,
-      address3: 1,
-      city: 1,
-      state: 1,
-      postalCode: 1,
-      country: 1,
-      company: 1,
-      email: 0,
-      phone: 0,
-      ssn: 0,
-      username: 1,
-      passportNumber: 1,
-      licenseNumber: 1,
-    }
+const ATTRIBUTES_AMBIGUITY: any = {
+  identity: {
+    title: 1,
+    firstName: 1,
+    middleName: 1,
+    lastName: 1,
+    address1: 1,
+    address2: 1,
+    address3: 1,
+    city: 1,
+    state: 1,
+    postalCode: 1,
+    country: 1,
+    company: 1,
+    email: 0,
+    phone: 0,
+    ssn: 0,
+    username: 1,
+    passportNumber: 1,
+    licenseNumber: 1,
+  },
+  card: {
+    cardholderName: 1,
+    brand: 1,
+    number: 1,
+    expMonth: 0,
+    expYear: 0,
+    code: 1,
+  },
+  login: {
+    uris: 1,
+    username: 1,
+    password: 1,
+    passwordRevisionDate: 1,
+    totp: 1,
+  },
+  contact: {
+    title: 1,
+    firstName: 1,
+    middleName: 1,
+    lastName: 1,
+    address1: 1,
+    address2: 1,
+    address3: 1,
+    city: 1,
+    state: 1,
+    postalCode: 1,
+    country: 1,
+    company: 1,
+    email: 0,
+    phone: 0,
+    ssn: 0,
+    username: 1,
+    passportNumber: 1,
+    licenseNumber: 1,
+  },
+};
+
+export const makeDecisionArray = (scriptContext: any): DecisionArray => {
+  // check if the field is associated to an ambiguous attribute of a cipher
+  const ambiguity =
+    ATTRIBUTES_AMBIGUITY[scriptContext.cipher.type][scriptContext.cipher.fieldType] ?? 0;
+  // prepare decision array used to decide if the script should be run for this field
+  const decisionArray: DecisionArray = {
+    connected: scriptContext.connected,
+    hasExistingCipher: scriptContext.hasExistingCipher,
+    hasLoginCipher: scriptContext.hasLoginCipher,
+    hasCardCipher: scriptContext.hasCardCipher,
+    hasIdentityCipher: scriptContext.hasIdentityCipher,
+    hasContactCipher: scriptContext.hasContactCipher,
+    ambiguity: ambiguity,
+    loginFellows: scriptContext.loginFellows,
+    cardFellows: scriptContext.cardFellows,
+    identityFellows: scriptContext.identityFellows,
+    contactFellows: scriptContext.contactFellows,
+    field_isInForm: scriptContext.field.isInForm,
+    field_isInSearchForm: scriptContext.field.isInSearchForm,
+    field_isInloginForm: scriptContext.field.isInloginForm,
+    field_isInSignupForm: scriptContext.field.isInSignupForm,
+    hasMultipleScript: scriptContext.hasMultipleScript,
+    field_visible: scriptContext.field.visible,
+    field_viewable: scriptContext.field.viewableOri, // use the original value
   };
 
-  export const makeDecisionArray = (scriptContext: any): DecisionArray => {
-    // check if the field is associated to an ambiguous attribute of a cipher
-    const ambiguity = ATTRIBUTES_AMBIGUITY[scriptContext.cipher.type][scriptContext.cipher.fieldType] ?? 0;
-    // prepare decision array used to decide if the script should be run for this field
-    const decisionArray: DecisionArray = {
-      connected: scriptContext.connected,
-      hasExistingCipher: scriptContext.hasExistingCipher,
-      hasLoginCipher: scriptContext.hasLoginCipher,
-      hasCardCipher: scriptContext.hasCardCipher,
-      hasIdentityCipher: scriptContext.hasIdentityCipher,
-      hasContactCipher: scriptContext.hasContactCipher,
-      ambiguity: ambiguity,
-      loginFellows: scriptContext.loginFellows,
-      cardFellows: scriptContext.cardFellows,
-      identityFellows: scriptContext.identityFellows,
-      contactFellows: scriptContext.contactFellows,
-      field_isInForm: scriptContext.field.isInForm,
-      field_isInSearchForm: scriptContext.field.isInSearchForm,
-      field_isInloginForm: scriptContext.field.isInloginForm,
-      field_isInSignupForm: scriptContext.field.isInSignupForm,
-      hasMultipleScript: scriptContext.hasMultipleScript,
-      field_visible: scriptContext.field.visible,
-      field_viewable: scriptContext.field.viewableOri, // use the original value
-    };
+  return decisionArray;
+};
 
-    return decisionArray;
+/* -------------------------------------------------------------------------------- */
+// Evaluate if a decision array is valid to activate a menu for the field in the page.
+export const evaluateDecisionArray = (action: any) => {
+  const da = action[3].decisionArray as DecisionArray;
+  // selection conditions
+  if (
+    da.hasExistingCipher === true &&
+    da.field_isInForm === true &&
+    da.field_isInSearchForm === false
+  ) {
+    return true;
   }
-  
-  /* -------------------------------------------------------------------------------- */
-  // Evaluate if a decision array is valid to activate a menu for the field in the page.
-  export const evaluateDecisionArray = (action: any) => {
-    const da = action[3].decisionArray as DecisionArray;
-    // selection conditions
-    if (
-      da.hasExistingCipher === true &&
-      da.field_isInForm === true &&
-      da.field_isInSearchForm === false
-    ) {
-      return true;
-    }
-    if (da.field_isInSearchForm === true) {
-      return false;
-    }
-    if (
-      da.connected === true &&
-      da.hasExistingCipher === true &&
-      da.loginFellows > 1 &&
-      da.field_visible === true
-    ) {
-      return true;
-    }
-    if (da.ambiguity === 1 && da.cardFellows > 1 && da.field_isInForm === true) {
-      return true;
-    }
-    if (da.ambiguity === 0 && da.cardFellows > 3 && da.field_isInForm === true) {
-      return true;
-    }
-    if (
-      da.connected === true &&
-      da.hasIdentityCipher === true &&
-      da.identityFellows > 1 &&
-      da.field_visible === true
-    ) {
-      return true;
-    }
-    if (
-      da.connected === true &&
-      da.hasContactCipher === true &&
-      da.contactFellows > 1 &&
-      da.field_visible === true
-    ) {
-      return true;
-    }
-    if (da.connected === false && da.loginFellows === 2) {
-      return true;
-    }
-    if (da.connected === false && da.hasLoginCipher === true && da.field_isInloginForm === true) {
-      return true;
-    }
-    if (da.connected === false && da.hasLoginCipher === true && da.field_isInSignupForm === true) {
-      return true;
-    }
-    if (da.ambiguity === 0 && da.identityFellows > 0 && da.field_isInForm === true) {
-      return true;
-    }
-    if (da.ambiguity === 1 && da.identityFellows > 1 && da.field_isInForm === true) {
-      return true;
-    }
-    if (da.ambiguity === 0 && da.contactFellows > 0 && da.field_isInForm === true) {
-      return true;
-    }
-    if (da.ambiguity === 1 && da.contactFellows > 1 && da.field_isInForm === true) {
-      return true;
-    }
-    if (da.connected === true && da.hasExistingCipher === undefined && da.hasLoginCipher === true) {
-      return false;
-    }
-    // end selection conditions
+  if (da.field_isInSearchForm === true) {
     return false;
   }
-
-  export interface DecisionArray {
-    /** If the extension is logged in */
-    connected: boolean
-    /** At least one field in the page corresponds to a field in an existing cipher */
-    hasExistingCipher: boolean
-    /** The field corresponds to at least 1 field of a generic Login cipher */
-    hasLoginCipher: boolean
-    /** The field corresponds to at least 1 field of a generic Card cipher */
-    hasCardCipher: boolean
-    /** The field corresponds to at least 1 field of a generic Identity cipher */
-    hasIdentityCipher: boolean
-    /** The field corresponds to at least 1 field of a generic Contact cipher */
-    hasContactCipher: boolean
-    /** Sometimes 1 field is not enough to guess which types of cipher are eligibles
-     * For exemple, the field `email` is not enough to guess that we are in an Identity form or a Login form
-     * But if we have more related field like `firstName`, `phone` or `ssn`, then we can guess that it is an Identity form
-     * 1 if we accept that an anbiguous field triggers the corresponding type, 0 otherwise */
-    ambiguity: number
-    /** Number of fields in the page corresponding to a generic Login cipher */
-    loginFellows: number
-    /** Number of fields in the page corresponding to a generic Card cipher */
-    cardFellows: number
-    /** Number of fields in the page corresponding to a generic Identity cipher */
-    identityFellows: number
-    /** Number of fields in the page corresponding to a generic Contact cipher */
-    contactFellows: number
-    /** If the field is inside a `<form>` element */
-    field_isInForm: boolean
-    /** If the field is inside a `<form>` element that contains search related terms (i.e. `search`, `recherche`) */
-    field_isInSearchForm: boolean
-    /** If the field is inside a `<form>` element that contains login related terms (i.e. `login`, `signin`) */
-    field_isInloginForm: boolean
-    /** If the field is inside a `<form>` element that contains signup related terms (i.e. `signup`, `register`) */
-    field_isInSignupForm: boolean
-    /** If the `<form>` has multiple fields with the same `fieldType` (i.e. `login_email`, `login_password`) */
-    hasMultipleScript: boolean
-    /** If none of the field's parents is `display=none` or `visibility=hidden` */
-    field_visible: boolean
-    /** If the field is visible AND the user doesn't have to scroll to have it displayed in the viewport */
-    field_viewable: boolean
+  if (
+    da.connected === true &&
+    da.hasExistingCipher === true &&
+    da.loginFellows > 1 &&
+    da.field_visible === true
+  ) {
+    return true;
   }
+  if (da.ambiguity === 1 && da.cardFellows > 1 && da.field_isInForm === true) {
+    return true;
+  }
+  if (da.ambiguity === 0 && da.cardFellows > 3 && da.field_isInForm === true) {
+    return true;
+  }
+  if (
+    da.connected === true &&
+    da.hasIdentityCipher === true &&
+    da.identityFellows > 1 &&
+    da.field_visible === true
+  ) {
+    return true;
+  }
+  if (
+    da.connected === true &&
+    da.hasContactCipher === true &&
+    da.contactFellows > 1 &&
+    da.field_visible === true
+  ) {
+    return true;
+  }
+  if (da.connected === false && da.loginFellows === 2) {
+    return true;
+  }
+  if (da.connected === false && da.hasLoginCipher === true && da.field_isInloginForm === true) {
+    return true;
+  }
+  if (da.connected === false && da.hasLoginCipher === true && da.field_isInSignupForm === true) {
+    return true;
+  }
+  if (da.ambiguity === 0 && da.identityFellows > 0 && da.field_isInForm === true) {
+    return true;
+  }
+  if (da.ambiguity === 1 && da.identityFellows > 1 && da.field_isInForm === true) {
+    return true;
+  }
+  if (da.ambiguity === 0 && da.contactFellows > 0 && da.field_isInForm === true) {
+    return true;
+  }
+  if (da.ambiguity === 1 && da.contactFellows > 1 && da.field_isInForm === true) {
+    return true;
+  }
+  if (da.connected === true && da.hasExistingCipher === undefined && da.hasLoginCipher === true) {
+    return false;
+  }
+  // end selection conditions
+  return false;
+};
+
+export interface DecisionArray {
+  /** If the extension is logged in */
+  connected: boolean;
+  /** At least one field in the page corresponds to a field in an existing cipher */
+  hasExistingCipher: boolean;
+  /** The field corresponds to at least 1 field of a generic Login cipher */
+  hasLoginCipher: boolean;
+  /** The field corresponds to at least 1 field of a generic Card cipher */
+  hasCardCipher: boolean;
+  /** The field corresponds to at least 1 field of a generic Identity cipher */
+  hasIdentityCipher: boolean;
+  /** The field corresponds to at least 1 field of a generic Contact cipher */
+  hasContactCipher: boolean;
+  /** Sometimes 1 field is not enough to guess which types of cipher are eligibles
+   * For exemple, the field `email` is not enough to guess that we are in an Identity form or a Login form
+   * But if we have more related field like `firstName`, `phone` or `ssn`, then we can guess that it is an Identity form
+   * 1 if we accept that an anbiguous field triggers the corresponding type, 0 otherwise */
+  ambiguity: number;
+  /** Number of fields in the page corresponding to a generic Login cipher */
+  loginFellows: number;
+  /** Number of fields in the page corresponding to a generic Card cipher */
+  cardFellows: number;
+  /** Number of fields in the page corresponding to a generic Identity cipher */
+  identityFellows: number;
+  /** Number of fields in the page corresponding to a generic Contact cipher */
+  contactFellows: number;
+  /** If the field is inside a `<form>` element */
+  field_isInForm: boolean;
+  /** If the field is inside a `<form>` element that contains search related terms (i.e. `search`, `recherche`) */
+  field_isInSearchForm: boolean;
+  /** If the field is inside a `<form>` element that contains login related terms (i.e. `login`, `signin`) */
+  field_isInloginForm: boolean;
+  /** If the field is inside a `<form>` element that contains signup related terms (i.e. `signup`, `register`) */
+  field_isInSignupForm: boolean;
+  /** If the `<form>` has multiple fields with the same `fieldType` (i.e. `login_email`, `login_password`) */
+  hasMultipleScript: boolean;
+  /** If none of the field's parents is `display=none` or `visibility=hidden` */
+  field_visible: boolean;
+  /** If the field is visible AND the user doesn't have to scroll to have it displayed in the viewport */
+  field_viewable: boolean;
+}

--- a/apps/browser/src/inPageMenu/menu.html
+++ b/apps/browser/src/inPageMenu/menu.html
@@ -29,6 +29,8 @@
 
       <div id="card-rows-list" class="rows-list"></div>
 
+      <div id="contact-rows-list" class="rows-list"></div>
+
       <div id="ids-rows-list" class="rows-list"></div>
 
       <div id="arrow"></div>

--- a/apps/browser/src/inPageMenu/menu.js
+++ b/apps/browser/src/inPageMenu/menu.js
@@ -89,7 +89,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (msg.command === "updateMenuCiphers") {
       const ciphersData = msg.data.ciphers;
-      ciphers = { cards: [], identities: [], logins: [] };
+      ciphers = { cards: [], identities: [], logins: [], contacts: [] };
 
       ciphersData.cards.forEach((cd) => {
         ciphers.cards.push(mapData2CipherView(cd, new CipherView()));
@@ -99,6 +99,9 @@ document.addEventListener("DOMContentLoaded", () => {
       });
       ciphersData.logins.forEach((cd) => {
         ciphers.logins.push(mapData2CipherView(cd, new CipherView()));
+      });
+      ciphersData.contacts.forEach((cd) => {
+        ciphers.contacts.push(mapData2CipherView(cd, new CipherView()));
       });
 
       document.getElementById("logo-link").href = msg.data.cozyUrl;
@@ -155,17 +158,19 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // 6- listen to click on the rows
-  document.querySelectorAll("#login-rows-list, #card-rows-list, #ids-rows-list").forEach((list) => {
-    list.addEventListener("click", (e) => {
-      const rowEl = e.target.closest(".row-main");
-      const detailEl = e.target.closest(".row-detail");
-      if (detailEl) {
-        requestFieldFillingWithData(detailEl.textContent);
-      } else {
-        requestFormFillingWithCipher(rowEl.dataset.cipherId);
-      }
+  document
+    .querySelectorAll("#login-rows-list, #card-rows-list, #ids-rows-list, #contact-rows-list")
+    .forEach((list) => {
+      list.addEventListener("click", (e) => {
+        const rowEl = e.target.closest(".row-main");
+        const detailEl = e.target.closest(".row-detail");
+        if (detailEl) {
+          requestFieldFillingWithData(detailEl.textContent);
+        } else {
+          requestFormFillingWithCipher(rowEl.dataset.cipherId);
+        }
+      });
     });
-  });
 
   // 7- detect when to apply the fadeIn effect
   window.addEventListener("hashchange", _testHash);
@@ -202,6 +207,7 @@ function updateAllRows() {
   updateRows("login");
   updateRows("card");
   updateRows("ids");
+  updateRows("contact");
   selectFirstVisibleRow();
 }
 
@@ -235,6 +241,14 @@ function updateRows(rowsListType) {
       }
       rowsCiphers = ciphers.identities;
       rowsList = document.querySelector("#ids-rows-list");
+      rowTemplate = idsRowTemplate;
+      break;
+    case "contact":
+      if (!ciphers || !ciphers.contacts) {
+        return;
+      }
+      rowsCiphers = ciphers.contacts;
+      rowsList = document.querySelector("#contact-rows-list");
       rowTemplate = idsRowTemplate;
       break;
   }
@@ -276,6 +290,13 @@ function updateRows(rowsListType) {
           default:
             detail.textContent = cipher.identity[currentFieldData.identity];
         }
+        break;
+      case "contact":
+        text.textContent = cipher.name;
+        detail.textContent =
+          cipher.contact.primaryEmail !== cipher.contact.displayName
+            ? cipher.contact.primaryEmail
+            : null;
         break;
     }
   });
@@ -367,6 +388,9 @@ function mapData2CipherView(cData, cView) {
     case CipherType.Identity:
       _mapData2Obj(cData.identity, cView.identity);
       break;
+    case CipherType.Contact:
+      _mapData2Obj(cData.contact, cView.contact);
+      break;
   }
   const propNotTocopy = ["card", "login", "identity", "secureNote"];
   for (var key in cData) {
@@ -433,6 +457,12 @@ function _testHash() {
       title: i18nGetMessage("inPageMenuSelectAnAccount"),
       updateFn: () => updateRows("login"),
       selector: "#login-rows-list",
+    },
+    {
+      fieldCipherType: "contact",
+      title: i18nGetMessage("inPageMenuSelectAContact"),
+      updateFn: () => updateRows("contact"),
+      selector: "#contacts-rows-list",
     },
   ];
 

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -331,6 +331,7 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
     }
     if (!dontShowIdentities) {
       otherTypes.push(CipherType.Identity);
+      otherTypes.push(CipherType.Contact);
     }
 
     const ciphers = await this.cipherService.getAllDecryptedForUrl(

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -451,14 +451,14 @@ export class CipherService implements CipherServiceAbstraction {
         return false;
       }
       if (includeOtherTypes != null && includeOtherTypes.indexOf(cipher.type) > -1) {
+        // Cozy customization
+        if (cipher.type === CipherType.Contact) {
+          return cipher.favorite || cipher.contact.me;
+        }
+        // Cozy customization end
+
         return true;
       }
-
-      // Cozy customization
-      if (cipher.type === CipherType.Contact) {
-        return cipher.favorite || cipher.contact.me;
-      }
-      // Cozy customization end
 
       if (url != null && cipher.type === CipherType.Login && cipher.login.uris != null) {
         for (let i = 0; i < cipher.login.uris.length; i++) {


### PR DESCRIPTION
We want Contacts ciphers to appear in the InPage menu

In order to keep the menu usable, for now we limite the menu to display only `me` and favorites contacts

In the future we may implement a search feature allowing to access other contacts