### PR TITLE
Add an "I understand" button to profiles migration component

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -2428,7 +2428,7 @@
   "encryptedInfoMoreDetails": {
     "message": "More details"
   },
-  "encryptedInfoDismiss": {
+  "understood": {
     "message": "I understand"
   },
   "home": {

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -2476,7 +2476,7 @@
   "encryptedInfoMoreDetails": {
     "message": "En savoir plus"
   },
-  "encryptedInfoDismiss": {
+  "understood": {
     "message": "J'ai compris"
   },
   "home": {

--- a/apps/browser/src/cozy/components/encrypted-info/encrypted-info.component.html
+++ b/apps/browser/src/cozy/components/encrypted-info/encrypted-info.component.html
@@ -10,7 +10,7 @@
         {{ "encryptedInfoMoreDetails" | i18n }}
       </button>
       <button type="button" class="btn link" (click)="dismiss()">
-        {{ "encryptedInfoDismiss" | i18n }}
+        {{ "understood" | i18n }}
       </button>
     </div>
   </div>

--- a/apps/browser/src/cozy/components/profiles-migration/profiles-migration.component.html
+++ b/apps/browser/src/cozy/components/profiles-migration/profiles-migration.component.html
@@ -1,4 +1,4 @@
-<div class="profileMigration" *ngIf="ready && profilesCount > 0">
+<div class="profileMigration" *ngIf="ready && !profilesMigrationHidden && profilesCount > 0">
   <div class="alert warning">
     <div class="alert-icon cozy-icon-info"></div>
     <div class="alert-message">
@@ -13,6 +13,9 @@
     <div class="alert-action">
       <button type="button" class="btn link" (click)="moreInfo()">
         {{ "profileMigrationAction" | i18n }}
+      </button>
+      <button type="button" class="btn link" (click)="understood()">
+        {{ "understood" | i18n }}
       </button>
     </div>
   </div>

--- a/apps/browser/src/cozy/components/profiles-migration/profiles-migration.component.ts
+++ b/apps/browser/src/cozy/components/profiles-migration/profiles-migration.component.ts
@@ -22,6 +22,7 @@ export class ProfilesMigrationComponent implements OnInit {
   remaining: string;
   deadline: string;
   ready = false;
+  profilesMigrationHidden = false;
   constructor(
     protected cipherService: CipherService,
     protected i18nService: I18nService,
@@ -42,6 +43,8 @@ export class ProfilesMigrationComponent implements OnInit {
       locale: this.i18nService.systemLanguage === "fr" ? fr : undefined,
       unit: "day",
     });
+
+    this.profilesMigrationHidden = await this.stateService.getProfilesMigrationHidden();
 
     const didClean = await this.handleDeadline(cleanDeadline);
 
@@ -69,6 +72,11 @@ export class ProfilesMigrationComponent implements OnInit {
     }
 
     return true;
+  }
+
+  protected async understood() {
+    await this.stateService.setProfilesMigrationHidden(true);
+    this.profilesMigrationHidden = true;
   }
 
   moreInfo() {

--- a/libs/common/src/abstractions/state.service.ts
+++ b/libs/common/src/abstractions/state.service.ts
@@ -381,5 +381,7 @@ export abstract class StateService<T extends Account = Account> {
   //*
   getProfilesCleanDeadline: (options?: StorageOptions) => Promise<Date | null>;
   setProfilesCleanDeadline: (value: Date, options?: StorageOptions) => Promise<void>;
+  getProfilesMigrationHidden: (options?: StorageOptions) => Promise<boolean>;
+  setProfilesMigrationHidden: (value: boolean, options?: StorageOptions) => Promise<void>;
   //*/
 }

--- a/libs/common/src/models/domain/account.ts
+++ b/libs/common/src/models/domain/account.ts
@@ -192,6 +192,10 @@ export class AccountProfile {
   kdfMemory?: number;
   kdfParallelism?: number;
   kdfType?: KdfType;
+  // Cozy customization, clean profiles after X days
+  //*
+  profilesMigrationHidden?: boolean;
+  //*/
 
   static fromJSON(obj: Jsonify<AccountProfile>): AccountProfile {
     if (obj == null) {

--- a/libs/common/src/models/domain/account.ts
+++ b/libs/common/src/models/domain/account.ts
@@ -244,6 +244,10 @@ export class AccountSettings {
   avatarColor?: string;
   activateAutoFillOnPageLoadFromPolicy?: boolean;
   smOnboardingTasks?: Record<string, Record<string, boolean>>;
+  // Cozy customization, clean profiles after X days
+  //*
+  profilesCleanDeadline?: string;
+  //*/
 
   static fromJSON(obj: Jsonify<AccountSettings>): AccountSettings {
     if (obj == null) {

--- a/libs/common/src/models/domain/global-state.ts
+++ b/libs/common/src/models/domain/global-state.ts
@@ -49,8 +49,4 @@ export class GlobalState {
   enableBrowserIntegration?: boolean;
   enableBrowserIntegrationFingerprint?: boolean;
   enableDuckDuckGoBrowserIntegration?: boolean;
-  // Cozy customization, clean profiles after X days
-  //*
-  profilesCleanDeadline: string;
-  //*/
 }

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -2911,8 +2911,8 @@ export class StateService<
   //*
   async getProfilesCleanDeadline(options?: StorageOptions): Promise<Date | null> {
     const valueString = (
-      await this.getGlobals(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
-    )?.profilesCleanDeadline;
+      await this.getAccount(this.reconcileOptions(options, await this.defaultOnDiskLocalOptions()))
+    )?.settings?.profilesCleanDeadline;
 
     if (valueString) {
       return parseISO(valueString);
@@ -2922,12 +2922,12 @@ export class StateService<
   }
 
   async setProfilesCleanDeadline(value: Date, options?: StorageOptions): Promise<void> {
-    const globals = await this.getGlobals(
+    const account = await this.getAccount(
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );
-    globals.profilesCleanDeadline = formatISO(value);
-    await this.saveGlobals(
-      globals,
+    account.settings.profilesCleanDeadline = formatISO(value);
+    await this.saveAccount(
+      account,
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );
   }

--- a/libs/common/src/services/state.service.ts
+++ b/libs/common/src/services/state.service.ts
@@ -2931,6 +2931,27 @@ export class StateService<
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );
   }
+
+  async getProfilesMigrationHidden(options?: StorageOptions): Promise<boolean | null> {
+    return (
+      (
+        await this.getAccount(
+          this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+        )
+      )?.profile?.profilesMigrationHidden ?? false
+    );
+  }
+
+  async setProfilesMigrationHidden(value: boolean, options?: StorageOptions): Promise<void> {
+    const account = await this.getAccount(
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+    account.profile.profilesMigrationHidden = value;
+    await this.saveAccount(
+      account,
+      this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
+    );
+  }
   //*/
 }
 


### PR DESCRIPTION
"I understand" button hide the profiles migration component until the next logout/login.

![Screenshot 2024-04-30 at 10 13 06](https://github.com/cozy/cozy-keys-browser/assets/10849491/9613da62-dc3e-44b7-923c-2be76489a597)

Also moved `profilesCleanDeadline` to `account.settings` so it will avoid two users to share the same `profilesCleanDeadline`.
