### PR TITLE
Order and wording fixes

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -733,10 +733,10 @@
     "message": "List card items on the Tab page for easy auto-fill."
   },
   "showIdentitiesCurrentTab": {
-    "message": "Show profiles on Tab page"
+    "message": "Show contacts on Tab page"
   },
   "showIdentitiesCurrentTabDesc": {
-    "message": "List profiles on the Tab page for easy auto-fill."
+    "message": "List contacts on the Tab page for easy auto-fill."
   },
   "clearClipboard": {
     "message": "Clear clipboard",

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -736,10 +736,10 @@
     "message": "Lister les éléments de la carte sur la page de l'onglet pour faciliter la saisie automatique."
   },
   "showIdentitiesCurrentTab": {
-    "message": "Afficher les profils sur la page Onglet courant"
+    "message": "Afficher les contacts sur la page Onglet courant"
   },
   "showIdentitiesCurrentTabDesc": {
-    "message": "Lister les profils sur la page de l'onglet en cours pour faciliter la saisie automatique."
+    "message": "Lister les contacts sur la page de l'onglet en cours pour faciliter la saisie automatique."
   },
   "clearClipboard": {
     "message": "Effacer le presse-papiers",

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.html
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.html
@@ -153,6 +153,36 @@
       </div>
     </div>
     <!-- Cozy customization -->
+    <!-- Add me and favorite Cozy Contacts -->
+    <div class="box list">
+      <!---->
+      <h2 class="box-header">
+        {{ "typeContacts" | i18n }}
+      </h2>
+      <div class="box-content">
+        <app-cipher-row
+          *ngFor="let contactCipher of contactCiphers"
+          [cipher]="contactCipher"
+          title="{{ 'viewItem' | i18n }}"
+          [showView]="false"
+          (onSelected)="viewCipher($event)"
+          (onView)="viewCipher($event)"
+          (onAutofill)="fillCipher(contactCipher)"
+        ></app-cipher-row>
+        <!-- Cozy custo -->
+        <div
+          class="box-content-row padded no-hover"
+          *ngIf="contactCiphers && !contactCiphers.length"
+        >
+          <p class="text-center">{{ "addContactExplanation" | i18n }}</p>
+          <button type="button" class="btn link block" (click)="addContactCipher()">
+            {{ "addContact" | i18n }}
+          </button>
+        </div>
+        <!-- end custo -->
+      </div>
+    </div>
+    <!-- Cozy customization -->
     <!-- Disable Profiles if empty as they will be replaced by Cozy Contacts -->
     <div class="box list" *ngIf="identityCiphers.length > 0">
       <!---->
@@ -180,36 +210,6 @@
           <p class="text-center">{{ "addIdentityExplanation" | i18n }}</p>
           <button type="button" class="btn link block" (click)="addIdentityCipher()">
             {{ "addIdentity" | i18n }}
-          </button>
-        </div>
-        <!-- end custo -->
-      </div>
-    </div>
-    <!-- Cozy customization -->
-    <!-- Add me and favorite Cozy Contacts -->
-    <div class="box list">
-      <!---->
-      <h2 class="box-header">
-        {{ "typeContacts" | i18n }}
-      </h2>
-      <div class="box-content">
-        <app-cipher-row
-          *ngFor="let contactCipher of contactCiphers"
-          [cipher]="contactCipher"
-          title="{{ 'viewItem' | i18n }}"
-          [showView]="false"
-          (onSelected)="viewCipher($event)"
-          (onView)="viewCipher($event)"
-          (onAutofill)="fillCipher(contactCipher)"
-        ></app-cipher-row>
-        <!-- Cozy custo -->
-        <div
-          class="box-content-row padded no-hover"
-          *ngIf="contactCiphers && !contactCiphers.length"
-        >
-          <p class="text-center">{{ "addContactExplanation" | i18n }}</p>
-          <button type="button" class="btn link block" (click)="addContactCipher()">
-            {{ "addContact" | i18n }}
           </button>
         </div>
         <!-- end custo -->

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.html
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.html
@@ -125,7 +125,9 @@
         </div>
       </div>
     </div>
-    <div class="box list">
+    <!-- Cozy customization -->
+    <!-- Disable Cards if type is hidden -->
+    <div class="box list" *ngIf="!dontShowCards">
       <h2 class="box-header">
         {{ "cards" | i18n }}
         <!-- Cozy custo : commented
@@ -154,7 +156,7 @@
     </div>
     <!-- Cozy customization -->
     <!-- Add me and favorite Cozy Contacts -->
-    <div class="box list">
+    <div class="box list" *ngIf="!dontShowIdentities">
       <!---->
       <h2 class="box-header">
         {{ "typeContacts" | i18n }}
@@ -183,8 +185,8 @@
       </div>
     </div>
     <!-- Cozy customization -->
-    <!-- Disable Profiles if empty as they will be replaced by Cozy Contacts -->
-    <div class="box list" *ngIf="identityCiphers.length > 0">
+    <!-- Disable Profiles if type is hidden or if empty as they will be replaced by Cozy Contacts -->
+    <div class="box list" *ngIf="!dontShowIdentities && identityCiphers.length > 0">
       <!---->
       <h2 class="box-header">
         {{ "identities" | i18n }}

--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -65,6 +65,8 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
   autofillCalloutText: string[] = ["", ""];
   protected search$ = new Subject<void>();
   private destroy$ = new Subject<void>();
+  dontShowCards = false;
+  dontShowIdentities = false;
 
   private totpCode: string;
   private totpTimeout: number;
@@ -333,6 +335,11 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
       otherTypes.push(CipherType.Identity);
       otherTypes.push(CipherType.Contact);
     }
+
+    // Cozy customization, forward dontShowCards and dontShowIdentities
+    // to view to hide completely these types if we do not want to show them
+    this.dontShowCards = dontShowCards;
+    this.dontShowIdentities = dontShowIdentities;
 
     const ciphers = await this.cipherService.getAllDecryptedForUrl(
       this.url,

--- a/libs/common/src/vault/services/cipher.service.ts
+++ b/libs/common/src/vault/services/cipher.service.ts
@@ -163,6 +163,10 @@ export class CipherService implements CipherServiceAbstraction {
     cipher.reprompt = model.reprompt;
     cipher.edit = model.edit;
 
+    // Cozy customization; creationDate is not forwarded during encrypt contrary to revisionDate.
+    // I did not understand why. We need it so we forward it here.
+    cipher.creationDate = model.creationDate;
+
     if (key == null && cipher.organizationId != null) {
       key = await this.cryptoService.getOrgKey(cipher.organizationId);
       if (key == null) {

--- a/libs/cozy/contact.helper.ts
+++ b/libs/cozy/contact.helper.ts
@@ -41,9 +41,15 @@ export const convertContactToCipherData = async (
   cipherView.contact.initials = getInitials(contact);
   cipherView.contact.primaryEmail = getPrimaryEmail(contact);
   cipherView.contact.primaryPhone = getPrimaryPhone(contact);
-  cipherView.favorite = !!cozyMetadata?.favorite;
   cipherView.fields = buildFieldsFromContact(i18nService, contact);
   cipherView.contact.me = contact.me;
+
+  if (cozyMetadata?.favorite === undefined && contact.me) {
+    cipherView.favorite = true;
+  } else {
+    cipherView.favorite = !!cozyMetadata?.favorite;
+  }
+
   if (cozyMetadata?.createdAt) {
     cipherView.creationDate = new Date(cozyMetadata.createdAt);
   }


### PR DESCRIPTION
fix: Invert order of contacts and profiles in current tab
fix: Migrate profile setting wording
fix: Show nothing in "For this web page" if a type is disabled for this page
fix: Sort paper by date was not working because missing creation date