### PR TITLE
fix: Do not need to click multiple times in page menu to display it

### DIFF
--- a/apps/browser/src/inPageMenu/menu.js
+++ b/apps/browser/src/inPageMenu/menu.js
@@ -472,7 +472,7 @@ function _testHash() {
       fieldCipherType: "contact",
       title: i18nGetMessage("inPageMenuSelectAContact"),
       updateFn: () => updateRows("contact"),
-      selector: "#contacts-rows-list",
+      selector: "#contact-rows-list",
     },
   ];
 


### PR DESCRIPTION
After a page load, we needed to click multiple times on the in page menu to display it. It was because we used "#contact-row-list" everywhere, except in one place where we used "#contacts-row-list" leading to errors.