### PR TITLE
fix: Display again contacts in in page menu

### DIFF
--- a/apps/browser/src/inPageMenu/menu.js
+++ b/apps/browser/src/inPageMenu/menu.js
@@ -482,7 +482,9 @@ function _testHash() {
     if (oldFieldData && oldFieldData[key] === hash[key]) {
       continue;
     }
-    if (hash[key]) {
+    // At this point, a contact is considered as an identity so we need to remove the hidden class
+    // for existing type and also for contact if identity exists
+    if (hash[key] || (key === "contact" && hash["identity"])) {
       titleEl.textContent = options.title;
       options.updateFn();
       rowsEl.classList.remove("hidden");


### PR DESCRIPTION
Following previous fix that avoid _testHash to crash (99ae740), contacts were
not displayed because we consider them as identities, so we never removed the "hidden" class.

Let's remove it if identities "hidden" class is removed.