### PR TITLE
fix: Update Firefox min version to publish

### DIFF
--- a/apps/browser/src/manifest.json
+++ b/apps/browser/src/manifest.json
@@ -108,7 +108,7 @@
   "applications": {
     "gecko": {
       "id": "{d99217fe-4f35-4ede-8dc8-728920f75c26}",
-      "strict_min_version": "57.0"
+      "strict_min_version": "91.0"
     }
   },
   "sidebar_action": {


### PR DESCRIPTION
Mozilla Addons requires Firefox min version >= 58.0. We set the version of the Bitwarden merge upstream which is 91.0