### PR TITLE
Foundation of paper autofilling paper data with id card number

### DIFF
--- a/apps/browser/docs/T08.0-Identity-with-paper-data.html
+++ b/apps/browser/docs/T08.0-Identity-with-paper-data.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" media="screen" type="text/css" href="TXX.css"/>
+    </head>
+
+    <body>
+
+        <a href="./">Back to menu</a>
+        <hr>
+        <h2>Identity form with paper data</h2>
+        <p>autofill should insert data from io.cozy.files data if they exist for the autofilled io.cozy.contacts</p>
+
+        <form class="form autosave-enabled" id="dossier-edit-form" method="post">
+            <div class="editable-champ editable-champ-text">
+                <label for="name">Nom de famille
+                </label>
+                <input placeholder="Nom de famille" required="required" type="text" value="" id="name">
+            </div>
+
+            <div class="editable-champ editable-champ-text" >
+              <label for="numCni">Numéro de carte d'identité
+              </label>
+              <input placeholder="Numéro de carte d'identité" required="required" type="text" value="" id="numCni">
+            </div>
+
+        </form>
+
+    </body>
+</html>

--- a/apps/browser/docs/index.html
+++ b/apps/browser/docs/index.html
@@ -29,6 +29,7 @@
                     <li><a href="T03.5-identity-with-a-lastname-and-firstname-filed-EN.html"            >Identity form - with a field asking for lastName and firstName -EN</a></li>
                     <li><a href="T03.4-identity-with-a-firstname-and-lastname-filed-DE.html"            >Identity form - with a field asking for firstName and lastName -DE</a></li>
                     <li><a href="T03.5-identity-with-a-lastname-and-firstname-filed-DE.html"            >Identity form - with a field asking for lastName and firstName -DE</a></li>
+                    <li><a href="T08.0-Identity-with-paper-data.html"            >Identity form - with paper data</a></li>
                 </ul>
             </li>
             <br>

--- a/apps/browser/src/autofill/enums/autofill-field.enums.ts
+++ b/apps/browser/src/autofill/enums/autofill-field.enums.ts
@@ -23,6 +23,9 @@ export const AutofillFieldQualifier = {
   identityPhone: "identityPhone",
   identityEmail: "identityEmail",
   identityUsername: "identityUsername",
+  // Cozy customization
+  paperIdentityCardNumber: "paperIdentityCardNumber",
+  // Cozy customization end
 } as const;
 
 export type AutofillFieldQualifierType =

--- a/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/inline-menu-field-qualifications.service.ts
@@ -38,4 +38,7 @@ export interface InlineMenuFieldQualificationService {
   isFieldForIdentityPhone(field: AutofillField): boolean;
   isFieldForIdentityEmail(field: AutofillField): boolean;
   isFieldForIdentityUsername(field: AutofillField): boolean;
+  // Cozy customization
+  isFieldForPaperIdentityCardNumber(field: AutofillField): boolean;
+  // Cozy customization end
 }

--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -829,3 +829,53 @@ export class IdentityAutoFillConstants {
     saskatchewan: "SK",
   };
 }
+
+// Cozy customization
+
+export class PaperAutoFillConstants {
+  static readonly PaperAttributes: string[] = [
+    "autoCompleteType",
+    "data-stripe",
+    "htmlName",
+    "htmlID",
+    "label-tag",
+    "placeholder",
+    "label-left",
+    "label-top",
+    "data-recurly",
+  ];
+
+  static readonly IdentityCardNumberFieldNames: string[] = [
+    "cniNum",
+    "numCni",
+    "idcni",
+    "cniId",
+    "numeroCarteIdendite",
+    "carteIdenditeNumero",
+    "carteidentite ",
+    "Numéro de la carte d'identité",
+    "Numéro d'identification",
+    "Numéro d'identité",
+    "Numéro de pièce d'identité",
+    "Numéro de carte d'identité",
+    "Identifiant personnel",
+    "Identifiant d'identification",
+    "ID de carte d'identité",
+    "Code d'identification",
+    "Numéro d'identification officiel",
+    "Numéro d'enregistrement personnel",
+    "Identity card number",
+    "Identification number",
+    "Identity number",
+    "Identity document number",
+    "Identity card number",
+    "Personal identifier",
+    "Identification ID",
+    "ID card ",
+    "Identification code",
+    "Official identification number",
+    "Personal registration number",
+  ];
+}
+
+// Cozy customization end

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -126,6 +126,10 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       this.inlineMenuFieldQualificationService.isFieldForIdentityEmail,
     [AutofillFieldQualifier.identityUsername]:
       this.inlineMenuFieldQualificationService.isFieldForIdentityUsername,
+    // Cozy customization
+    [AutofillFieldQualifier.paperIdentityCardNumber]:
+      this.inlineMenuFieldQualificationService.isFieldForPaperIdentityCardNumber,
+    // Cozy customization end
   };
 
   constructor(private inlineMenuFieldQualificationService: InlineMenuFieldQualificationService) {}

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -38,6 +38,8 @@ import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { CipherService } from "@bitwarden/common/vault/services/cipher.service";
 import { TotpService } from "@bitwarden/common/vault/services/totp.service";
 
+import { CozyClientService } from "src/popup/services/cozyClient.service";
+
 import { BrowserApi } from "../../platform/browser/browser-api";
 import { BrowserScriptInjectorService } from "../../platform/services/browser-script-injector.service";
 import { AutofillMessageCommand, AutofillMessageSender } from "../enums/autofill-message.enums";
@@ -89,6 +91,7 @@ describe("AutofillService", () => {
   let authService: MockProxy<AuthService>;
   let configService: MockProxy<ConfigService>;
   let messageListener: MockProxy<MessageListener>;
+  let cozyClientService: MockProxy<CozyClientService>;
 
   beforeEach(() => {
     scriptInjectorService = new BrowserScriptInjectorService(platformUtilsService, logService);
@@ -100,6 +103,7 @@ describe("AutofillService", () => {
     authService.activeAccountStatus$ = activeAccountStatusMock$;
     configService = mock<ConfigService>();
     messageListener = mock<MessageListener>();
+    cozyClientService = mock<CozyClientService>();
     autofillService = new AutofillService(
       cipherService,
       autofillSettingsService,
@@ -114,6 +118,7 @@ describe("AutofillService", () => {
       authService,
       configService,
       messageListener,
+      cozyClientService,
     );
     domainSettingsService = new DefaultDomainSettingsService(fakeStateProvider);
     domainSettingsService.equivalentDomains$ = of(mockEquivalentDomains);

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -48,6 +48,7 @@ import {
   AutoFillConstants,
   CreditCardAutoFillConstants,
   IdentityAutoFillConstants,
+  PaperAutoFillConstants,
 } from "./autofill-constants";
 
 /* start Cozy imports */
@@ -55,6 +56,7 @@ import {
 import { CozyClientService } from "src/popup/services/cozyClient.service";
 import { generateIdentityViewFromCipherView } from "../../../../../libs/cozy/contact.helper";
 import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
+import { getCozyValue } from "../../../../../libs/cozy/mapping";
 /* eslint-enable */
 /* end Cozy imports */
 
@@ -664,6 +666,13 @@ export default class AutofillService implements AutofillServiceInterface {
         }
 
         fillScript = this.generateIdentityFillScript(
+          fillScript,
+          pageDetails,
+          filledFields,
+          options,
+        );
+
+        fillScript = await this.generatePaperFillScript(
           fillScript,
           pageDetails,
           filledFields,
@@ -1487,6 +1496,72 @@ export default class AutofillService implements AutofillServiceInterface {
 
     return fillScript;
   }
+
+  // Cozy customization
+
+  /**
+   * Generates the autofill script for the specified page details and paper data.
+   * @param {AutofillScript} fillScript
+   * @param {AutofillPageDetails} pageDetails
+   * @param {{[p: string]: AutofillField}} filledFields
+   * @param {GenerateFillScriptOptions} options
+   * @returns {AutofillScript}
+   * @private
+   */
+  private async generatePaperFillScript(
+    fillScript: AutofillScript,
+    pageDetails: AutofillPageDetails,
+    filledFields: { [id: string]: AutofillField },
+    options: GenerateFillScriptOptions,
+  ): Promise<AutofillScript> {
+    const fillFields: { [id: string]: AutofillField } = {};
+
+    pageDetails.fields.forEach((f) => {
+      if (
+        AutofillService.isExcludedFieldType(f, AutoFillConstants.ExcludedAutofillTypes) ||
+        ["current-password", "new-password"].includes(f.autoCompleteType)
+      ) {
+        return;
+      }
+
+      for (let i = 0; i < PaperAutoFillConstants.PaperAttributes.length; i++) {
+        const attr = PaperAutoFillConstants.PaperAttributes[i];
+        // eslint-disable-next-line
+        if (!f.hasOwnProperty(attr) || !f[attr] || !f.viewable) {
+          continue;
+        }
+        // FIXME: Check if we will be able to factorize the code
+        if (
+          !fillFields.paperIdentityCardNumber &&
+          AutofillService.isFieldMatch(f[attr], PaperAutoFillConstants.IdentityCardNumberFieldNames)
+        ) {
+          fillFields.paperIdentityCardNumber = f;
+          break;
+        }
+      }
+    });
+
+    const client = await this.cozyClientService.getClientInstance();
+
+    // FIXME: Check if we will be able to factorize the code
+    if (fillFields.paperIdentityCardNumber) {
+      const paperIdentityCardNumber = await getCozyValue({
+        client,
+        contactId: options.cipher.id,
+        fieldQualifier: "paperIdentityCardNumber",
+      });
+      this.makeScriptActionWithValue(
+        fillScript,
+        paperIdentityCardNumber,
+        fillFields.paperIdentityCardNumber,
+        filledFields,
+      );
+    }
+
+    return fillScript;
+  }
+
+  // Cozy customization end
 
   /**
    * Accepts an HTMLInputElement type value and a list of

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -52,6 +52,7 @@ import {
 
 /* start Cozy imports */
 /* eslint-disable */
+import { CozyClientService } from "src/popup/services/cozyClient.service";
 import { generateIdentityViewFromCipherView } from "../../../../../libs/cozy/contact.helper";
 import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
 /* eslint-enable */
@@ -78,6 +79,7 @@ export default class AutofillService implements AutofillServiceInterface {
     private authService: AuthService,
     private configService: ConfigService,
     private messageListener: MessageListener,
+    private cozyClientService: CozyClientService,
   ) {}
 
   /**

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -1049,10 +1049,21 @@ export class InlineMenuFieldQualificationService
   ) {
     const searchedValues = this.getAutofillFieldDataKeywords(autofillFieldData, fuzzyMatchKeywords);
     if (typeof searchedValues === "string") {
+      // Cozy customization, compare lowercase keyword and lowercase searchedValue
+      //*
+      return keywords.some((keyword) => searchedValues.indexOf(keyword.toLowerCase()) > -1);
+      /*/
       return keywords.some((keyword) => searchedValues.indexOf(keyword) > -1);
+      //*/
     }
 
+    // Cozy customization, compare lowercase keyword and lowercase searchedValue
+    //*
+    return keywords.some((keyword) => searchedValues.has(keyword.toLowerCase()));
+
+    /*/
     return keywords.some((keyword) => searchedValues.has(keyword));
+    //*/
   }
 
   /**

--- a/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
+++ b/apps/browser/src/autofill/services/inline-menu-field-qualification.service.ts
@@ -10,6 +10,7 @@ import {
   AutoFillConstants,
   CreditCardAutoFillConstants,
   IdentityAutoFillConstants,
+  PaperAutoFillConstants,
 } from "./autofill-constants";
 
 export class InlineMenuFieldQualificationService
@@ -137,6 +138,9 @@ export class InlineMenuFieldQualificationService
       ...IdentityAutoFillConstants.PhoneFieldNames,
       ...IdentityAutoFillConstants.EmailFieldNames,
       ...IdentityAutoFillConstants.UserNameFieldNames,
+      // Cozy customization
+      ...PaperAutoFillConstants.IdentityCardNumberFieldNames,
+      // Cozy customization end
     ]),
   ];
   private inlineMenuFieldQualificationFlagSet = false;
@@ -824,6 +828,26 @@ export class InlineMenuFieldQualificationService
       this.keywordsFoundInFieldData(field, IdentityAutoFillConstants.UserNameFieldNames, false)
     );
   };
+
+  // Cozy customization
+
+  /**
+   * Validates the provided field as an identity username field.
+   *
+   * @param field - The field to validate
+   */
+  isFieldForPaperIdentityCardNumber = (field: AutofillField): boolean => {
+    return (
+      !this.fieldContainsAutocompleteValues(field, this.autocompleteDisabledValues) &&
+      this.keywordsFoundInFieldData(
+        field,
+        PaperAutoFillConstants.IdentityCardNumberFieldNames,
+        false,
+      )
+    );
+  };
+
+  // Cozy customization end
 
   /**
    * Validates the provided field as a username field.

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -953,6 +953,7 @@ export default class MainBackground {
       this.authService,
       this.configService,
       messageListener,
+      this.cozyClientService,
     );
     this.auditService = new AuditService(this.cryptoFunctionService, this.apiService);
 

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -337,6 +337,7 @@ const safeProviders: SafeProvider[] = [
       AuthService,
       ConfigService,
       MessageListener,
+      CozyClientService,
     ],
   }),
   safeProvider({

--- a/libs/cozy/mapping.ts
+++ b/libs/cozy/mapping.ts
@@ -1,0 +1,82 @@
+import CozyClient, { Q } from "cozy-client";
+import _ from "lodash";
+
+import {
+  AutofillFieldQualifier,
+  AutofillFieldQualifierType,
+} from "../../apps/browser/src/autofill/enums/autofill-field.enums";
+
+export type CozyAttributesModel = {
+  doctype: string;
+  path: string;
+  selector: {
+    [key: string]: string;
+  };
+};
+
+export type CozyAttributesMapping = {
+  [key in AutofillFieldQualifierType]?: CozyAttributesModel;
+};
+
+export const COZY_ATTRIBUTES_MAPPING: CozyAttributesMapping = {
+  [AutofillFieldQualifier.paperIdentityCardNumber]: {
+    doctype: "io.cozy.files",
+    path: "metadata.number",
+    selector: { "metadata.qualification.label": "national_id_card" },
+  },
+};
+
+interface GetCozyValueType {
+  client: CozyClient;
+  contactId: string;
+  fieldQualifier: AutofillFieldQualifierType;
+}
+
+export const getCozyValue = async ({
+  client,
+  contactId,
+  fieldQualifier,
+}: GetCozyValueType): Promise<string | undefined> => {
+  const cozyAttributeModel = COZY_ATTRIBUTES_MAPPING[fieldQualifier];
+
+  if (!cozyAttributeModel) {
+    return;
+  }
+
+  if (cozyAttributeModel.doctype === "io.cozy.files") {
+    return await getCozyValueInPaper({
+      client,
+      contactId,
+      cozyAttributeModel,
+    });
+  }
+};
+
+interface GetCozyValueInPaperType {
+  client: CozyClient;
+  contactId: string;
+  cozyAttributeModel: CozyAttributesModel;
+}
+
+const getCozyValueInPaper = async ({
+  client,
+  contactId,
+  cozyAttributeModel,
+}: GetCozyValueInPaperType) => {
+  // FIXME: Temporary way to query data. We want to avoid online request.
+  const { data: papers } = await client.query(
+    Q("io.cozy.files").where({
+      ...cozyAttributeModel.selector,
+    }),
+  );
+
+  const papersFromContact = papers.filter((paper: any) => isReferencedByContact(paper, contactId));
+
+  return _.get(papersFromContact[0], cozyAttributeModel.path);
+};
+
+const isReferencedByContact = (paper: any, contactId: string) => {
+  return paper?.relationships?.referenced_by?.data?.find(
+    (reference: any) => reference.id === contactId && reference.type === "io.cozy.contacts",
+  );
+};


### PR DESCRIPTION
In this PR, I add the foundation of autofilling paper data when autofilling a contact by taking as example the id card number.

https://github.com/user-attachments/assets/38f8935b-e5d5-4902-a816-5a1a2c7e2220

The paper data autofill expand the fillscript of a contact. 

Tested : 
- contact autofill from popup fill the id card number
- id card number field open the inline menu with contacts
- contact autofill from inline menu fill the id card number



