### PR TITLE
fix: Redirect button to the Cozy

### DIFF
--- a/apps/browser/src/popup/services/cozyClient.service.ts
+++ b/apps/browser/src/popup/services/cozyClient.service.ts
@@ -63,11 +63,10 @@ export class CozyClientService {
   }
 
   getCozyURL(): string {
-    const vaultUrl = this.environmentService.getWebVaultUrlSync();
-    if (!vaultUrl) {
+    if (!this.instance.stackClient.uri) {
       return null;
     }
-    return new URL(vaultUrl).origin; // Remove the /bitwarden part
+    return new URL(this.instance.stackClient.uri).origin;
   }
 
   async getCozyUrlAsync(): Promise<string> {

--- a/libs/common/src/platform/abstractions/environment.service.ts
+++ b/libs/common/src/platform/abstractions/environment.service.ts
@@ -95,8 +95,6 @@ export abstract class EnvironmentService {
   abstract environment$: Observable<Environment>;
   abstract cloudWebVaultUrl$: Observable<string>;
 
-  abstract getWebVaultUrlSync(): string;
-
   /**
    * Retrieve all the available regions for environment selectors.
    *

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -125,12 +125,6 @@ export class DefaultEnvironmentService implements EnvironmentService {
   private globalState: GlobalState<EnvironmentState | null>;
   private globalCloudRegionState: GlobalState<CloudRegion | null>;
 
-  protected webVaultUrlSync: string;
-
-  getWebVaultUrlSync() {
-    return this.webVaultUrlSync;
-  }
-
   // We intentionally don't want the helper on account service, we want the null back if there is no active user
   private activeAccountId$: Observable<UserId | null> = this.accountService.activeAccount$.pipe(
     map((a) => a?.id),
@@ -237,8 +231,6 @@ export class DefaultEnvironmentService implements EnvironmentService {
           keyConnector: urls.keyConnector,
         },
       }));
-
-      this.webVaultUrlSync = formatUrl(urls.webVault);
 
       return urls;
     }


### PR DESCRIPTION
Since the merge upstream, the method of retrieving the cozy URL has changed. (see 4a2dee6)

The new approach was not functional.
As the `this.webVaultUrlSync` property defines its value in an async method, when `getCozyURL()` is called `this.webVaultUrlSync` is not yet set.