### PR TITLE
fix: Duplicate toast informations

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/cozy-utils.ts
+++ b/apps/browser/src/vault/popup/components/vault/cozy-utils.ts
@@ -55,7 +55,7 @@ export const deleteCipher = async (
       : cipherService.softDeleteWithServer(cipher.id);
     const message = i18nService.t(cipher.isDeleted ? "permanentlyDeletedItem" : "deletedItem");
     await deletePromise;
-    toastService.showToast({ title: message, message, variant: "success" });
+    toastService.showToast({ title: message, message: "", variant: "success" });
     const onDeletedCipher = new EventEmitter<CipherView>();
     onDeletedCipher.emit(cipher);
   } catch {

--- a/libs/cozy/contactCipher.ts
+++ b/libs/cozy/contactCipher.ts
@@ -127,7 +127,7 @@ export const deleteContactCipher = async (
   await cipherService.delete(cipher.id);
 
   const message = i18nService.t("deletedContactItem");
-  toastService.showToast({ title: message, message, variant: "success" });
+  toastService.showToast({ title: message, message: "", variant: "success" });
 
   return true;
 };

--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -177,7 +177,7 @@ export const deletePaperCipher = async (
   await cipherService.delete(cipher.id);
 
   const message = i18nService.t("deletedPaperItem");
-  toastService.showToast({ title: message, message, variant: "success" });
+  toastService.showToast({ title: message, message: "", variant: "success" });
 
   return true;
 };


### PR DESCRIPTION
Some toasts display the same information twice.
This change ensures that only the title is displayed in these toasts, giving the user a cleaner, more concise experience.