### PR TITLE
feat: Save attribute value in contact

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -268,7 +268,6 @@ export type InlineMenuListPortMessageHandlers = {
   redirectAutofillInlineMenuFocusOut: ({ message, port }: PortOnMessageHandlerParams) => void;
   updateAutofillInlineMenuListHeight: ({ message, port }: PortOnMessageHandlerParams) => void;
   redirectToCozy: ({ message, port }: PortOnMessageHandlerParams) => void;
-  handleMenuListUpdate: ({ message, port }: PortOnMessageHandlerParams) => void;
   editInlineMenuCipher: ({ message, port }: PortOnMessageHandlerParams) => void;
 };
 

--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -268,7 +268,6 @@ export type InlineMenuListPortMessageHandlers = {
   redirectAutofillInlineMenuFocusOut: ({ message, port }: PortOnMessageHandlerParams) => void;
   updateAutofillInlineMenuListHeight: ({ message, port }: PortOnMessageHandlerParams) => void;
   redirectToCozy: ({ message, port }: PortOnMessageHandlerParams) => void;
-  editInlineMenuCipher: ({ message, port }: PortOnMessageHandlerParams) => void;
 };
 
 export interface OverlayBackground {

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -172,7 +172,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       this.fillAutofillInlineMenuCipherWithAmbiguousField(message, port),
     inlineMenuSearchContact: ({ message }) => this.searchContacts(message),
     redirectToCozy: ({ message }) => this.redirectToCozy(message),
-    handleMenuListUpdate: ({ message, port }) => this.handleMenuListUpdate(message, port),
     editInlineMenuCipher: ({ message }) => this.editInlineMenuCipher(message),
     // Cozy customization end
     addNewVaultItem: ({ message, port }) => this.getNewVaultItemDetails(message, port),
@@ -212,20 +211,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       command: "editContactFields",
       inlineMenuCipherId,
       contactName: contact.displayName,
-    });
-  };
-  // Cozy customization end
-
-  // Cozy customization
-  private handleMenuListUpdate = async (message: OverlayPortMessage, port: chrome.runtime.Port) => {
-    const { inlineMenuCipherId } = message;
-    // If ambiguous field is manually filled, inlineMenuCipherId is undefined
-    if (inlineMenuCipherId) {
-      return this.handleContactClick(message, port);
-    }
-
-    this.inlineMenuListPort?.postMessage({
-      command: "loadPageOfCiphers",
     });
   };
   // Cozy customization end

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -172,7 +172,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       this.fillAutofillInlineMenuCipherWithAmbiguousField(message, port),
     inlineMenuSearchContact: ({ message }) => this.searchContacts(message),
     redirectToCozy: ({ message }) => this.redirectToCozy(message),
-    editInlineMenuCipher: ({ message }) => this.editInlineMenuCipher(message),
     // Cozy customization end
     addNewVaultItem: ({ message, port }) => this.getNewVaultItemDetails(message, port),
     viewSelectedCipher: ({ message, port }) => this.viewSelectedCipher(message, port),
@@ -196,24 +195,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   ) {
     this.initOverlayEventObservables();
   }
-
-  // Cozy customization
-  private editInlineMenuCipher = async (message: OverlayPortMessage) => {
-    const { inlineMenuCipherId } = message;
-    const client = await this.cozyClientService.getClientInstance();
-    const cipher = this.inlineMenuCiphers.get(inlineMenuCipherId);
-
-    const { data: contact } = (await client.query(Q(CONTACTS_DOCTYPE).getById(cipher.id), {
-      executeFromStore: true,
-    })) as { data: IOCozyContact };
-
-    this.inlineMenuListPort?.postMessage({
-      command: "editContactFields",
-      inlineMenuCipherId,
-      contactName: contact.displayName,
-    });
-  };
-  // Cozy customization end
 
   private redirectToCozy = (message: OverlayPortMessage) => {
     BrowserApi.createNewTab(this.cozyClientService.getAppURL(message.to, message.hash), true);

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -167,7 +167,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     fillAutofillInlineMenuCipher: ({ message, port }) => this.fillInlineMenuCipher(message, port),
     // Cozy customization
     handleContactClick: ({ message, port }) => this.handleContactClick(message, port),
-    saveFieldToCozyDoctype: ({ message, port }) => this.saveFieldToCozyDoctype(message, port),
+    saveFieldToCozyDoctype: ({ message }) => this.saveFieldToCozyDoctype(message),
     fillAutofillInlineMenuCipherWithAmbiguousField: ({ message, port }) =>
       this.fillAutofillInlineMenuCipherWithAmbiguousField(message, port),
     inlineMenuSearchContact: ({ message }) => this.searchContacts(message),
@@ -977,7 +977,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
   }
 
-  private async saveFieldToCozyDoctype(message: OverlayPortMessage, port: chrome.runtime.Port) {
+  private async saveFieldToCozyDoctype(message: OverlayPortMessage) {
     const { inlineMenuCipherId, fieldQualifier, newAutofillValue } = message;
 
     if (inlineMenuCipherId) {

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
@@ -61,11 +61,6 @@ export type AutofillInlineMenuListWindowMessageHandlers = {
   }: {
     message: UpdateAutofillInlineMenuListAmbiguousMessage;
   }) => void;
-  editContactFields: ({
-    message,
-  }: {
-    message: UpdateAutofillInlineMenuListAmbiguousMessage;
-  }) => void;
   createEmptyNameList: ({
     message,
   }: {

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -354,13 +354,12 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
       ambiguousContactFieldNames.includes(
         COZY_ATTRIBUTES_MAPPING[this.fieldQualifier].name as AmbiguousContactFieldName,
       ) &&
-      !isBack
+      !isBack && // case where we are already on the ambiguous list and wish to return to the contacts list.
+      this.lastFilledContactCipherId // If ambiguous field is manually filled, inlineMenuCipherId is undefined.
     ) {
       this.postMessageToParent({
-        command: "handleMenuListUpdate",
+        command: "handleContactClick",
         inlineMenuCipherId: this.lastFilledContactCipherId,
-        lastFilledContactCipherId: this.lastFilledContactCipherId,
-        fieldQualifier: this.fieldQualifier,
         fieldHtmlIDToFill: this.fieldHtmlID,
       });
     } else {

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -81,8 +81,6 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
         ),
       loadPageOfCiphers: () => this.loadPageOfCiphers(),
       focusAutofillInlineMenuList: () => this.focusInlineMenuList(),
-      editContactFields: ({ message }) =>
-        this.editContactFields(message.inlineMenuCipherId, message.contactName),
       createEmptyNameList: ({ message }) =>
         this.createEmptyNameList(message.inlineMenuCipherId, message.contactName),
     };
@@ -551,7 +549,8 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
 
   private createNewContactButtonByName(
     inlineMenuCipherId: string,
-    name: AmbiguousContactFieldName | string,
+    contactName: string,
+    attributName: AmbiguousContactFieldName | string,
   ) {
     const listItem = document.createElement("li");
     listItem.setAttribute("role", "listitem");
@@ -563,10 +562,10 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     const fillButton = document.createElement("button");
     fillButton.setAttribute("tabindex", "-1");
     fillButton.classList.add("fill-cipher-button", "inline-menu-list-action");
-    fillButton.setAttribute("aria-label", name);
+    fillButton.setAttribute("aria-label", attributName);
     fillButton.addEventListener(
       EVENTS.CLICK,
-      this.handleEditCipherClickEvent(inlineMenuCipherId, uniqueId()),
+      () => this.editContactFields(inlineMenuCipherId, contactName),
     );
 
     const radio = document.createElement("input");
@@ -579,7 +578,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     detailsSpan.classList.add("cipher-details");
 
     let nameSpanText;
-    switch (name) {
+    switch (attributName) {
       case "phone":
         nameSpanText = this.getTranslation("newPhone");
         break;
@@ -607,17 +606,6 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
 
     return listItem;
   }
-
-  private handleEditCipherClickEvent = (inlineMenuCipherId: string, UID: string) => {
-    return this.useEventHandlersMemo(
-      () =>
-        this.postMessageToParent({
-          command: "editInlineMenuCipher",
-          inlineMenuCipherId,
-        }),
-      `${UID}-edit-cipher-button-click-handler`,
-    );
-  };
 
   /**
    * @param ambiguousKey
@@ -693,7 +681,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     const emptyLi = this.createEmptyNameListItem();
     ulElement.appendChild(emptyLi);
 
-    const newButton = this.createNewContactButtonByName(inlineMenuCipherId, "newName");
+    const newButton = this.createNewContactButtonByName(inlineMenuCipherId, contactName, "newName");
     ulElement.appendChild(newButton);
 
     this.inlineMenuListContainer.appendChild(addNewLoginButtonContainer);
@@ -753,6 +741,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     if (isAmbiguousFieldFocused) {
       const newButton = this.createNewContactButtonByName(
         inlineMenuCipherId,
+        contactName,
         firstAmbiguousFieldName,
       );
       ulElement.appendChild(newButton);

--- a/libs/cozy/createOrUpdateCozyDoctype.ts
+++ b/libs/cozy/createOrUpdateCozyDoctype.ts
@@ -16,7 +16,7 @@ const {
   file: { uploadFileWithConflictStrategy },
 } = models;
 
-interface AutofillValue {
+export interface AutofillValue {
   value: string;
   type?: string;
   label?: string;

--- a/libs/cozy/getCozyValue.ts
+++ b/libs/cozy/getCozyValue.ts
@@ -146,9 +146,9 @@ export const selectDataWithCozyProfile = (data: any[] | undefined, cozyProfile?:
   // that will finish by return the first phone number and not the phone number we clicked
   const matchingValueData = data.find(
     (d) =>
-      (cozyProfile.number && cozyProfile.number === d.number) ||
-      (cozyProfile.formattedAddress && cozyProfile.formattedAddress === d.formattedAddress) ||
-      (cozyProfile.address && cozyProfile.address === d.address),
+      (cozyProfile?.number && cozyProfile.number === d.number) ||
+      (cozyProfile?.formattedAddress && cozyProfile.formattedAddress === d.formattedAddress) ||
+      (cozyProfile?.address && cozyProfile.address === d.address),
   );
 
   if (!type && !label && matchingValueData) {


### PR DESCRIPTION
Ajout de la sauvegarde de l'édition d'un champs ambigu (tel, etc) ou du nom d'un contact.

A l'exception de l'adresse qui est pour le moment pas encore assez bien détectée pour être fiable.