### PR TITLE
fix: Update CozyClient store on realtime events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "chalk": "4.1.2",
         "commander": "11.1.0",
         "core-js": "3.36.1",
-        "cozy-client": "48.17.0",
+        "cozy-client": "48.24.0",
         "cozy-device-helper": "3.0.0",
         "cozy-flags": "3.2.2",
         "cozy-logger": "1.10.4",
@@ -17069,9 +17069,9 @@
       }
     },
     "node_modules/cozy-client": {
-      "version": "48.17.0",
-      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-48.17.0.tgz",
-      "integrity": "sha512-t/bjydRZVA079ujrWKMShOYqusen8wSzvSOMKR1Jp1XQAEF+yPOzaAirh2NBqbt5Vad3NLgb8uZ6sBvd7EI2Sg==",
+      "version": "48.24.0",
+      "resolved": "https://registry.npmjs.org/cozy-client/-/cozy-client-48.24.0.tgz",
+      "integrity": "sha512-xPAryrhPmIwA5gfOq3M6Z0QcXhcLj86oskivXGmHpLHTgrkb2CZ8ktYSKo3QZbDgSSK2p5JzRZIe1vSbMj2t4w==",
       "dependencies": {
         "@cozy/minilog": "1.0.0",
         "@types/jest": "^26.0.20",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "zone.js": "0.13.3",
     "zxcvbn": "4.4.2",
     "@cozy/minilog": "1.0.0",
-    "cozy-client": "48.17.0",
+    "cozy-client": "48.24.0",
     "cozy-device-helper": "3.0.0",
     "cozy-flags": "3.2.2",
     "cozy-logger": "1.10.4",


### PR DESCRIPTION
When we had a realtime 'created' contact event, we added a cipher to the cipher list but the CozyClient store was not filled. So in the inline menu, we would see the contact but not autofill it because to autofill, we do a `client.query(query, { executeFromStore })` on the contact which returned null.