### PR TITLE
feat: Do autofill when clicking on autofill buttons on popup

### DIFF
--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -264,6 +264,11 @@ export default class RuntimeBackground {
       case "lockVault":
         await this.main.vaultTimeoutService.lock(msg.userId);
         break;
+      // Cozy customization
+      case "doAutoFill":
+        this.autofillService.doAutoFill(msg.autofillOptions);
+        break;
+      // Cozy customization end
       case "logout":
         await this.main.logout(msg.expired, msg.userId);
         break;


### PR DESCRIPTION
We customized Bitwarden autofill which now need a Cozy Client store with all the contacts inside.

Now with Manifest V3, there are :
- an autofill service and a CozyClient service for the background
- an autofill service and a CozyClient service for the extension popup

But only the CozyClient service of the background has its store filled with all the contacts inside fetched during the fullSync.

So we send the autofill action from the extension popup to the background.