### PR TITLE
feat: Add paper field names

### DIFF
--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -53,6 +53,7 @@ import {
 import {
   COZY_ATTRIBUTES_MAPPING,
   CozyContactFieldNames,
+  cozypaperFieldNames,
 } from "../../../../../../../../libs/cozy/mapping";
 import { CozyAutofillOptions } from "src/autofill/services/abstractions/autofill.service";
 import { fields } from "../../../../../../../../libs/cozy/contact.lib";
@@ -561,7 +562,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     // Cozy customization - On the contact ambiguous fields, if the field has a value, the corresponding menu is displayed directly. Unless we wish to return to the contact cypher list.
     if (
       this.fieldValue &&
-      [...ambiguousContactFieldNames, ...addressFieldNames].includes(
+      [...ambiguousContactFieldNames, ...addressFieldNames, ...cozypaperFieldNames].includes(
         COZY_ATTRIBUTES_MAPPING[this.fieldQualifier].name as AmbiguousContactFieldName,
       ) &&
       !isBack && // case where we are already on the ambiguous list and wish to return to the contacts list.

--- a/libs/cozy/mapping.ts
+++ b/libs/cozy/mapping.ts
@@ -83,6 +83,15 @@ export type CozyFieldsNamesMapping = {
   [key in CozyContactFieldNames]: AutofillFieldQualifierType;
 };
 
+export const cozypaperFieldNames: CozyPaperFieldNames[] = [
+  "number",
+  "confidentialNumber",
+  "licenseNumber",
+  "bicNumber",
+  "netSocialAmount",
+  "refTaxIncome",
+];
+
 export const COZY_FIELDS_NAMES_MAPPING: Partial<CozyFieldsNamesMapping> = {
   number: AutofillFieldQualifier.identityAddress1,
   address: AutofillFieldQualifier.identityAddress1,


### PR DESCRIPTION
To open the inline-menu at the right step when it is opened on a field that has already been filled in.