### PR TITLE
fix: Add a paper works again

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -10,7 +10,7 @@ import { LockedVaultPendingNotificationsData } from "./notification.background";
 /* eslint-disable */
 import { AutofillFieldQualifierType } from "src/autofill/enums/autofill-field.enums";
 import { AmbiguousContactFieldValue } from "src/autofill/types";
-import { InputRefValue } from "src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list";
+import { InputValues } from "src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list";
 /* eslint-enable */
 /* end Cozy imports */
 
@@ -150,7 +150,7 @@ export type OverlayPortMessage = {
   ambiguousValue?: AmbiguousContactFieldValue[0];
   to?: string; // For "redirectToCozy" command
   hash?: string; // For "redirectToCozy" command
-  inputValues?: InputRefValue; // For "saveFieldToCozyDoctype" command
+  inputValues?: InputValues; // For "saveFieldToCozyDoctype" command
   // Cozy customization end
 };
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -76,16 +76,15 @@ import { CONTACTS_DOCTYPE } from "cozy-client/dist/models/contact";
 import { nameToColor } from "cozy-ui/transpiled/react/Avatar/helpers";
 import { CozyClientService } from "../../popup/services/cozyClient.service";
 import { AmbiguousContactFieldName, AmbiguousContactFieldValue } from "src/autofill/types";
-import {
-  COZY_ATTRIBUTES_MAPPING,
-  CozyContactFieldNames,
-  isPaperAttributesModel,
-} from "../../../../../libs/cozy/mapping";
+import { COZY_ATTRIBUTES_MAPPING, isPaperAttributesModel } from "../../../../../libs/cozy/mapping";
 import { createOrUpdateCozyDoctype } from "../../../../../libs/cozy/createOrUpdateCozyDoctype";
 import { getCozyValue, getAllPapersFromContact } from "../../../../../libs/cozy/getCozyValue";
 import _ from "lodash";
 import { FILES_DOCTYPE } from "../../../../../libs/cozy/constants";
-import { cleanFormattedAddress } from "../../../../../libs/cozy/contact.helper";
+import {
+  buildAddressObjectFromInputValues,
+  cleanFormattedAddress,
+} from "../../../../../libs/cozy/contact.helper";
 /* eslint-enable */
 /* end Cozy imports */
 
@@ -1040,11 +1039,11 @@ export class OverlayBackground implements OverlayBackgroundInterface {
         logService: this.logService,
       });
 
-      const isAddress = Object.keys(inputValues).includes("street");
+      const isAddress = inputValues.values.some((inputValue) => inputValue.key === "street");
       // If is an address, we need set the value of the field to the formatted address, because getCozyValue refers to `formattedAddress` to return values corresponding to the postal address.
       const value = isAddress
-        ? cleanFormattedAddress(inputValues)
-        : inputValues[COZY_ATTRIBUTES_MAPPING[fieldQualifier].name];
+        ? cleanFormattedAddress(buildAddressObjectFromInputValues(inputValues))
+        : inputValues.values[0].value;
       this.fillInlineMenuCipher(message, port, {
         value,
         type: inputValues.type,

--- a/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list.ts
@@ -81,14 +81,21 @@ export type AutofillInlineMenuListWindowMessageHandlers = {
 };
 
 export type InputRef = {
-  [key in CozyContactFieldNames]: HTMLInputElement;
+  key: CozyContactFieldNames | CozyPaperFieldNames;
+  element: HTMLInputElement;
+  fieldQualifier: AutofillFieldQualifierType;
 };
 
 export type InputRefValue = {
-  [key in CozyContactFieldNames | CozyPaperFieldNames]: string;
-} & {
-  label: CozyAutofillOptions["label"];
-  type: CozyAutofillOptions["type"];
+  key: CozyContactFieldNames | CozyPaperFieldNames;
+  value: string;
+  fieldQualifier: AutofillFieldQualifierType;
+};
+
+export type InputValues = {
+  values: InputRefValue[];
+  label?: CozyAutofillOptions["label"];
+  type?: CozyAutofillOptions["type"];
 };
 
 export type EditContactButtonsParams = {

--- a/libs/cozy/createOrUpdateCozyDoctype.spec.ts
+++ b/libs/cozy/createOrUpdateCozyDoctype.spec.ts
@@ -3,7 +3,7 @@ import { IOCozyContact } from "cozy-client/types/types";
 import { AutofillFieldQualifier } from "../../apps/browser/src/autofill/enums/autofill-field.enums";
 
 import { createOrUpdateCozyContact } from "./createOrUpdateCozyDoctype";
-import { COZY_ATTRIBUTES_MAPPING } from "./mapping";
+import { ContactAttributesModel, COZY_ATTRIBUTES_MAPPING, CozyContactFieldNames } from "./mapping";
 
 describe("createOrUpdateCozyContact", () => {
   it("should add a new value to an array field with existing data", async () => {
@@ -22,9 +22,17 @@ describe("createOrUpdateCozyContact", () => {
       ],
     } as unknown as IOCozyContact;
     const fieldQualifier = AutofillFieldQualifier.identityEmail;
-    const cozyAttributeModel = COZY_ATTRIBUTES_MAPPING[fieldQualifier];
-    const newAutofillValue = {
-      value: "jdoe@test.com",
+    const cozyAttributeModels = [
+      COZY_ATTRIBUTES_MAPPING[fieldQualifier],
+    ] as ContactAttributesModel[];
+    const inputValues = {
+      values: [
+        {
+          key: "email" as CozyContactFieldNames,
+          fieldQualifier: "identityEmail",
+          value: "jdoe@test.com",
+        },
+      ],
       type: "work",
       label: "Work",
     };
@@ -50,8 +58,8 @@ describe("createOrUpdateCozyContact", () => {
     };
     const result = await createOrUpdateCozyContact({
       contact,
-      cozyAttributeModel,
-      newAutofillValue,
+      cozyAttributeModels,
+      inputValues,
     });
     expect(result).toEqual(expectedContact);
   });
@@ -64,9 +72,11 @@ describe("createOrUpdateCozyContact", () => {
       },
     } as unknown as IOCozyContact;
     const fieldQualifier = AutofillFieldQualifier.identityEmail;
-    const cozyAttributeModel = COZY_ATTRIBUTES_MAPPING[fieldQualifier];
-    const newAutofillValue = {
-      value: "jdoe@test.com",
+    const cozyAttributeModels = [
+      COZY_ATTRIBUTES_MAPPING[fieldQualifier],
+    ] as ContactAttributesModel[];
+    const inputValues = {
+      values: [{ key: "email" as CozyContactFieldNames, fieldQualifier, value: "jdoe@test.com" }],
       type: "work",
       label: "Work",
     };
@@ -86,8 +96,8 @@ describe("createOrUpdateCozyContact", () => {
     };
     const result = await createOrUpdateCozyContact({
       contact,
-      cozyAttributeModel,
-      newAutofillValue,
+      cozyAttributeModels,
+      inputValues,
     });
     expect(result).toEqual(expectedContact);
   });
@@ -100,9 +110,11 @@ describe("createOrUpdateCozyContact", () => {
       },
     } as unknown as IOCozyContact;
     const fieldQualifier = AutofillFieldQualifier.identityFirstName;
-    const cozyAttributeModel = COZY_ATTRIBUTES_MAPPING[fieldQualifier];
-    const newAutofillValue = {
-      value: "Jane",
+    const cozyAttributeModels = [
+      COZY_ATTRIBUTES_MAPPING[fieldQualifier],
+    ] as ContactAttributesModel[];
+    const inputValues = {
+      values: [{ key: "givenName" as CozyContactFieldNames, fieldQualifier, value: "Jane" }],
     };
     const expectedContact = {
       name: {
@@ -112,8 +124,8 @@ describe("createOrUpdateCozyContact", () => {
     };
     const result = await createOrUpdateCozyContact({
       contact,
-      cozyAttributeModel,
-      newAutofillValue,
+      cozyAttributeModels,
+      inputValues,
     });
     expect(result).toEqual(expectedContact);
   });
@@ -121,9 +133,11 @@ describe("createOrUpdateCozyContact", () => {
   it("should set a new value to an empty non-array field", async () => {
     const contact = {} as unknown as IOCozyContact;
     const fieldQualifier = AutofillFieldQualifier.identityFirstName;
-    const cozyAttributeModel = COZY_ATTRIBUTES_MAPPING[fieldQualifier];
-    const newAutofillValue = {
-      value: "Jane",
+    const cozyAttributeModels = [
+      COZY_ATTRIBUTES_MAPPING[fieldQualifier],
+    ] as ContactAttributesModel[];
+    const inputValues = {
+      values: [{ key: "givenName" as CozyContactFieldNames, fieldQualifier, value: "Jane" }],
     };
     const expectedContact = {
       name: {
@@ -132,8 +146,8 @@ describe("createOrUpdateCozyContact", () => {
     };
     const result = await createOrUpdateCozyContact({
       contact,
-      cozyAttributeModel,
-      newAutofillValue,
+      cozyAttributeModels,
+      inputValues,
     });
     expect(result).toEqual(expectedContact);
   });

--- a/libs/cozy/getCozyValue.spec.ts
+++ b/libs/cozy/getCozyValue.spec.ts
@@ -35,13 +35,15 @@ const EMPTY_PROFILE_WITH_PHONE: CozyAutofillOptions = {
 
 const VALUE_ONLY_PHONE_ELEMENT = { number: "0" };
 
-const HOME_ONLY_ELEMENT = { phone: "0", label: "home" };
+const HOME_ONLY_ELEMENT = { number: "0", label: "home" };
 
-const HOME_AND_TYPE_ELEMENT = { phone: "1", label: "home", type: "iPhone" };
+const HOME_AND_TYPE_ELEMENT = { number: "1", label: "home", type: "iPhone" };
 
-const WORK_ONLY_ELEMENT = { phone: "2", label: "work" };
+const WORK_ONLY_ELEMENT = { number: "2", label: "work" };
 
-const WORK_AND_TYPE_ELEMENT = { phone: "3", label: "work", type: "Cozy Cloud" };
+const WORK_AND_TYPE_ELEMENT = { number: "3", label: "work", type: "Cozy Cloud" };
+
+const OTHER_WORK_ONLY_ELEMENT = { number: "4", label: "work" };
 
 describe("mapping", () => {
   describe("isPaperFromContact", () => {
@@ -189,6 +191,17 @@ describe("mapping", () => {
         const dataArray = [HOME_ONLY_ELEMENT, WORK_ONLY_ELEMENT];
 
         expect(selectDataWithCozyProfile(dataArray, WORK_ONLY_PROFILE)).toEqual(WORK_ONLY_ELEMENT);
+      });
+
+      it("should return return corresponding value and same label element if value and label only", () => {
+        const dataArray = [WORK_ONLY_ELEMENT, OTHER_WORK_ONLY_ELEMENT];
+
+        expect(
+          selectDataWithCozyProfile(dataArray, {
+            value: "4",
+            label: "work",
+          }),
+        ).toEqual(OTHER_WORK_ONLY_ELEMENT);
       });
 
       it("should return return first same label and type element if correct label and type", () => {

--- a/libs/cozy/getCozyValue.ts
+++ b/libs/cozy/getCozyValue.ts
@@ -210,9 +210,8 @@ export const selectDataWithCozyProfile = (
   const type = cozyAutofillOptions?.type;
   const label = cozyAutofillOptions?.label;
 
-  // If we clicked on a phone number with no type and label,
-  // we want to autofill with this phone number and not evaluate the select data logic
-  // that will finish by return the first phone number and not the phone number we clicked
+  // If we clicked on a phone number and we are selecting the phone number field,
+  // we want this phone number whatever the type and label
   const matchingValueData = data.find(
     (d) =>
       cozyAutofillOptions?.value &&
@@ -221,7 +220,7 @@ export const selectDataWithCozyProfile = (
         cozyAutofillOptions.value === d.address),
   );
 
-  if (!type && !label && matchingValueData) {
+  if (matchingValueData) {
     return matchingValueData;
   }
 

--- a/libs/cozy/mapping.ts
+++ b/libs/cozy/mapping.ts
@@ -92,31 +92,6 @@ export const cozypaperFieldNames: CozyPaperFieldNames[] = [
   "refTaxIncome",
 ];
 
-export const COZY_FIELDS_NAMES_MAPPING: Partial<CozyFieldsNamesMapping> = {
-  number: AutofillFieldQualifier.identityAddress1,
-  address: AutofillFieldQualifier.identityAddress1,
-  street: AutofillFieldQualifier.identityAddress1,
-  code: AutofillFieldQualifier.identityPostalCode,
-  city: AutofillFieldQualifier.identityCity,
-  region: AutofillFieldQualifier.identityAddress1,
-  locality: AutofillFieldQualifier.addressLocality,
-  floor: AutofillFieldQualifier.addressFloor,
-  stairs: AutofillFieldQualifier.addressStairs,
-  apartment: AutofillFieldQualifier.addressApartment,
-  building: AutofillFieldQualifier.addressBuilding,
-  entrycode: AutofillFieldQualifier.addressEntrycode,
-  state: AutofillFieldQualifier.identityState,
-  postalCode: AutofillFieldQualifier.identityPostalCode,
-  country: AutofillFieldQualifier.identityCountry,
-  phone: AutofillFieldQualifier.identityPhone,
-  displayName: AutofillFieldQualifier.identityFullName,
-  givenName: AutofillFieldQualifier.identityFirstName,
-  additionalName: AutofillFieldQualifier.identityMiddleName,
-  familyName: AutofillFieldQualifier.identityLastName,
-  company: AutofillFieldQualifier.identityCompany,
-  email: AutofillFieldQualifier.identityEmail,
-};
-
 export const COZY_ATTRIBUTES_MAPPING: CozyAttributesMapping = {
   [AutofillFieldQualifier.identityFullName]: {
     doctype: CONTACTS_DOCTYPE,


### PR DESCRIPTION
Last implementation added support of addresses, but we lost the ability to know if we save a value to a contact or to a paper.

I changed the logic a little bit to support it again.

Kept :
- InputRef and InputRefValue duality (one for HTML element and one with the HTML element value)
- address is managed in a special case
- type and label are sent one time

Changed :
- we send the fieldQualifier with the HTML element value to be able to find the model.

So instead of sending :

{
  "street": "rue des champs" }

we send  :

{
  "key": "street", "fieldQualifier": "identityAddress1", // allow to get the model "value": "rue des champs" }

Also added country in hidden fields.