### PR TITLE
feat: Autofill the focus field first

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -870,7 +870,11 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       pageDetails: Array.from(pageDetails.values()),
       fillNewPassword: true,
       allowTotpAutofill: true,
-      cozyAutofillOptions,
+      cozyAutofillOptions: {
+        ...cozyAutofillOptions,
+        // Useful for Contacts CypherType
+        focusedFieldData: this.focusedFieldData,
+      },
     });
 
     // Cozy customization - Remembering the last filled cipher ID allows to open a custom UI in the inline menu but it works only for contacts.

--- a/apps/browser/src/autofill/services/abstractions/autofill.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill.service.ts
@@ -5,6 +5,7 @@ import { CommandDefinition } from "@bitwarden/common/platform/messaging";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import { FocusedFieldData } from "src/autofill/background/abstractions/overlay.background";
 import { AutofillFieldQualifierType } from "src/autofill/enums/autofill-field.enums";
 
 import { AutofillMessageCommand } from "../../enums/autofill-message.enums";
@@ -26,6 +27,7 @@ export interface CozyAutofillOptions {
   value?: string;
   fillOnlyThisFieldHtmlID?: string;
   fillOnlyTheseFieldQualifiers?: AutofillFieldQualifierType[];
+  focusedFieldData?: FocusedFieldData;
 }
 // Cozy customization end
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -727,6 +727,19 @@ export default class AutofillService implements AutofillServiceInterface {
         //  For papers, we only use the custom fields matching
         break;
       case CipherType.Contact:
+        // If we have two fields of the same type, for example tel1 and tel2.
+        // If we focus on tel2, we ignore tel1 and autofill tel2 and the rest of the form.
+        if (options.cozyAutofillOptions?.focusedFieldData) {
+          pageDetails = {
+            ...pageDetails,
+            fields: pageDetails.fields.filter(
+              (field) =>
+                field.fieldQualifier !==
+                  options.cozyAutofillOptions?.focusedFieldData.fieldQualifier || // on garde tous les champs d'un type autre que le champ focus
+                field.htmlID === options.cozyAutofillOptions?.focusedFieldData.fieldHtmlID, // par contre pour les champs du meme type que le champ focus, on garde que celui focus
+            ),
+          };
+        }
         // For contacts, we create an IdentityView with the contact content to leverage the generateIdentityFillScript
         try {
           const client = await this.cozyClientService.getClientInstance();

--- a/libs/cozy/createOrUpdateCozyDoctype.ts
+++ b/libs/cozy/createOrUpdateCozyDoctype.ts
@@ -6,6 +6,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import { AutofillFieldQualifierType } from "../../apps/browser/src/autofill/enums/autofill-field.enums";
 import type { InputValues } from "../../apps/browser/src/autofill/overlay/inline-menu/abstractions/autofill-inline-menu-list";
 
 import { CONTACTS_DOCTYPE, FILES_DOCTYPE } from "./constants";
@@ -48,7 +49,7 @@ export const createOrUpdateCozyDoctype = async ({
   logService,
 }: CreateOrUpdateCozyDoctypeType) => {
   const cozyAttributeModels = inputValues.values.map(
-    ({ fieldQualifier }) => COZY_ATTRIBUTES_MAPPING[fieldQualifier],
+    ({ fieldQualifier }) => COZY_ATTRIBUTES_MAPPING[fieldQualifier as AutofillFieldQualifierType],
   );
 
   if (cozyAttributeModels.length === 0) {
@@ -108,7 +109,8 @@ export const createOrUpdateCozyContact = async ({
   }
 
   for (const inputValue of inputValues.values) {
-    const cozyAttributeModel = COZY_ATTRIBUTES_MAPPING[inputValue.fieldQualifier];
+    const cozyAttributeModel =
+      COZY_ATTRIBUTES_MAPPING[inputValue.fieldQualifier as AutofillFieldQualifierType];
 
     if (cozyAttributeModel.isPathArray) {
       const arrayData = _.get(contact, cozyAttributeModel.path) || [];


### PR DESCRIPTION
If we have two fields of the same type, for example tel1 and tel2.
If we focus on tel2, we ignore tel1 and autofill tel2 and the rest of the form.