### PR TITLE
fix: Do autofill when clicking on autofill buttons on popup on Firefox

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/current-tab.component.ts
@@ -261,8 +261,8 @@ export class CurrentTabComponent implements OnInit, OnDestroy {
     try {
       // Cozy customization; send doAutoFill to background because
       // doAutoFill needs a Cozy Client store with all the contacts
-      // and only the background Cozy Client store has them
-      if (cipher.type === CipherType.Contact) {
+      // and only the background Cozy Client store has them on Manifest V3
+      if (cipher.type === CipherType.Contact && BrowserApi.isManifestVersion(3)) {
         this.messageSender.send("doAutoFill", {
           autofillOptions: {
             tab: this.tab,

--- a/apps/browser/src/vault/popup/components/vault/vault-items.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-items.component.ts
@@ -460,8 +460,8 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnIn
     try {
       // Cozy customization; send doAutoFill to background because
       // doAutoFill needs a Cozy Client store with all the contacts
-      // and only the background Cozy Client store has them
-      if (cipher.type === CipherType.Contact) {
+      // and only the background Cozy Client store has them on Manifest V3
+      if (cipher.type === CipherType.Contact && BrowserApi.isManifestVersion(3)) {
         this.messageSender.send("doAutoFill", {
           autofillOptions: {
             cipher: cipher,

--- a/apps/browser/src/vault/popup/components/vault/view.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/view.component.ts
@@ -511,8 +511,8 @@ export class ViewComponent extends BaseViewComponent implements OnInit, OnDestro
     try {
       // Cozy customization; send doAutoFill to background because
       // doAutoFill needs a Cozy Client store with all the contacts
-      // and only the background Cozy Client store has them
-      if (this.cipher.type === CipherType.Contact) {
+      // and only the background Cozy Client store has them on Manifest V3
+      if (this.cipher.type === CipherType.Contact && BrowserApi.isManifestVersion(3)) {
         this.messageSender.send("doAutoFill", {
           autofillOptions: {
             tab: this.tab,


### PR DESCRIPTION
In 6d3f39d1a29a4343977b5c242387a87ebfb6c654, we introduce a special way to do the autofill for Chrome because of Manifest 3. But this way does not work for Firefox which still use the Manifest 2 for the moment so let's add a strict check.