### PR TITLE
fix: Remove duplicate login key

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -25,9 +25,6 @@
   "finishCreatingYourAccountBySettingAPassword": {
     "message": "Finish creating your account by setting a password"
   },
-  "login": {
-    "message": "Log in"
-  },
   "forgotPassword": {
     "message": "I forgot my password"
   },

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -25,9 +25,6 @@
   "finishCreatingYourAccountBySettingAPassword": {
     "message": "Terminer la création de votre compte en définissant un mot de passe"
   },
-  "login": {
-    "message": "Me connecter"
-  },
   "forgotPassword": {
     "message": "J'ai oublié mon mot de passe"
   },

--- a/apps/browser/src/auth/popup/login.component.html
+++ b/apps/browser/src/auth/popup/login.component.html
@@ -81,7 +81,7 @@ No reconciliation is possible
       </div>
       <div class="content">
         <button class="btn primary block" type="submit" appBlurClick [disabled]="form.loading">
-          <span [hidden]="form.loading">{{ "login" | i18n }}</span>
+          <span [hidden]="form.loading">{{ "logIn" | i18n }}</span>
           <i
             class="bwi bwi-spinner bwi-lg bwi-spin"
             [hidden]="!form.loading"


### PR DESCRIPTION
Firefox Store is blocking the release because we have "login" and "logIn" key