### PR TITLE
feat: Improve performance by limiting papers and contacts synced

### DIFF
--- a/apps/browser/src/popup/services/cozyClient.service.ts
+++ b/apps/browser/src/popup/services/cozyClient.service.ts
@@ -162,6 +162,15 @@ export class CozyClientService {
             },
           },
         },
+        contacts: {
+          doctype: CONTACTS_DOCTYPE,
+          relationships: {
+            related: {
+              type: HasMany,
+              doctype: CONTACTS_DOCTYPE,
+            },
+          },
+        },
       },
       appMetadata: {
         slug: "passwords",

--- a/libs/cozy/contactCipher.ts
+++ b/libs/cozy/contactCipher.ts
@@ -15,7 +15,7 @@ import { DialogService, ToastService } from "@bitwarden/components";
 import { CozyClientService } from "../../apps/browser/src/popup/services/cozyClient.service";
 
 import { convertContactToCipherData } from "./contact.helper";
-import { fetchContacts, fetchContact } from "./queries";
+import { fetchContact } from "./queries";
 
 const convertContactsAsCiphers = async (
   cipherService: CipherService,
@@ -51,18 +51,14 @@ const convertContactsAsCiphers = async (
   return contactsCiphers;
 };
 
-export const fetchContactsAndConvertAsCiphers = async (
+export const convertAllContactsAsCiphers = async (
   cipherService: CipherService,
   cryptoService: CryptoService,
-  cozyClientService: CozyClientService,
   i18nService: I18nService,
   accountService: AccountService,
+  contacts: IOCozyContact[],
 ): Promise<CipherData[]> => {
-  const client = await cozyClientService.getClientInstance();
-
   try {
-    const contacts = await fetchContacts(client);
-
     const contactsCiphers = await convertContactsAsCiphers(
       cipherService,
       cryptoService,

--- a/libs/cozy/paperCipher.ts
+++ b/libs/cozy/paperCipher.ts
@@ -18,7 +18,7 @@ import { CozyClientService } from "../../apps/browser/src/popup/services/cozyCli
 import { FILES_DOCTYPE } from "./constants";
 import { convertNoteToCipherData, isNote, fetchNoteIllustrationUrl } from "./note.helper";
 import { convertPaperToCipherData } from "./paper.helper";
-import { fetchPapers, fetchPaper } from "./queries";
+import { fetchPaper } from "./queries";
 
 export const convertPapersAsCiphers = async (
   cipherService: CipherService,
@@ -76,18 +76,17 @@ export const convertPapersAsCiphers = async (
   return papersCiphers;
 };
 
-export const fetchPapersAndConvertAsCiphers = async (
+export const convertAllPapersAsCiphers = async (
   cipherService: CipherService,
   cryptoService: CryptoService,
   cozyClientService: CozyClientService,
   i18nService: I18nService,
   accountService: AccountService,
+  papers: any,
 ): Promise<CipherData[]> => {
   const client = await cozyClientService.getClientInstance();
 
   try {
-    const papers = await fetchPapers(client);
-
     const papersCiphers = await convertPapersAsCiphers(
       cipherService,
       cryptoService,

--- a/libs/cozy/sync.ts
+++ b/libs/cozy/sync.ts
@@ -1,0 +1,94 @@
+import { IOCozyContact, IOCozyFile } from "cozy-client/types/types";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { CryptoService } from "@bitwarden/common/platform/abstractions/crypto.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { CipherData } from "@bitwarden/common/vault/models/data/cipher.data";
+
+import { CozyClientService } from "../../apps/browser/src/popup/services/cozyClient.service";
+
+import { convertAllContactsAsCiphers } from "./contactCipher";
+import { convertAllPapersAsCiphers } from "./paperCipher";
+import { fetchContactsAndPapers } from "./queries";
+
+export const selectContactsAndPapers = (
+  contacts: IOCozyContact[],
+  papers: IOCozyFile[],
+): { filteredContacts: IOCozyContact[]; filteredPapers: IOCozyFile[] } => {
+  // #### For papers, we do nothing
+  const filteredPapers = papers;
+
+  // #### For contacts, we want
+  // 1. contacts from the query
+  // 2. contacts related to "me"
+  // 3. contacts referenced in papers
+  const contactsToKeep = new Map<string, IOCozyContact>();
+
+  // First we add contacts from the query (i.e. me and favorite contacts) and contacts related to "me"
+  contacts.forEach((contact) => {
+    contactsToKeep.set(contact._id, contact);
+
+    if (contact.me) {
+      // @ts-expect-error related added manually with an hydration
+      contact.related.data.forEach((relatedContact: IOCozyContact) => {
+        contactsToKeep.set(relatedContact._id, relatedContact);
+      });
+    }
+  });
+
+  // Then we add contacts referenced in papers
+  papers.forEach((paper) => {
+    // @ts-expect-error contacts added manually with an hydration
+    paper.contacts.data.forEach((contact: IOCozyContact) => {
+      contactsToKeep.set(contact._id, contact);
+    });
+  });
+
+  return {
+    filteredPapers,
+    filteredContacts: [...contactsToKeep.values()],
+  };
+};
+
+export const getCozyCiphers = async (
+  cipherService: CipherService,
+  cryptoService: CryptoService,
+  cozyClientService: CozyClientService,
+  i18nService: I18nService,
+  accountService: AccountService,
+): Promise<CipherData[]> => {
+  const client = await cozyClientService.getClientInstance();
+
+  const { contacts, papers } = await fetchContactsAndPapers(client);
+
+  const { filteredContacts, filteredPapers } = selectContactsAndPapers(contacts, papers);
+
+  const contactsCiphers = await convertAllContactsAsCiphers(
+    cipherService,
+    cryptoService,
+    i18nService,
+    accountService,
+    filteredContacts,
+  );
+  const papersCiphers = await convertAllPapersAsCiphers(
+    cipherService,
+    cryptoService,
+    cozyClientService,
+    i18nService,
+    accountService,
+    filteredPapers,
+  );
+
+  let cozyCiphers: CipherData[] = [];
+
+  // eslint-disable-next-line no-console
+  console.log(`${contactsCiphers.length} contacts ciphers will be added`);
+  cozyCiphers = cozyCiphers.concat(contactsCiphers);
+
+  // eslint-disable-next-line no-console
+  console.log(`${papersCiphers.length} papers ciphers will be added`);
+  cozyCiphers = cozyCiphers.concat(papersCiphers);
+
+  return cozyCiphers;
+};


### PR DESCRIPTION
Before we did the "fetch and convert papers" and the "fetch and convert contacts" in parallel and we were keeping all of them. The sync was very slow and the UI was very slow too if we had 1000+ elements.

Here we changed the process.

1. We fetch papers and contacts in parralel

2. We filter papers and contacts to keep only what we want. We need both elements to filter them because papers and contacts are linked (for example, we want to keep contacts that are referenced in papers).

3. We convert them as ciphers

I also created a new sync.ts file to separate our code from the Bitwarden sync service.