### PR TITLE
fix: Disable history for generator

### DIFF
--- a/apps/browser/src/popup/app-routing.module.ts
+++ b/apps/browser/src/popup/app-routing.module.ts
@@ -289,7 +289,7 @@ const routes: Routes = [
     path: "generator",
     component: GeneratorComponent,
     canActivate: [authGuard],
-    data: { state: "generator" },
+    data: { state: "generator", doNotSaveUrl: true },
   },
   ...extensionRefreshSwap(PasswordGeneratorHistoryComponent, CredentialGeneratorHistoryComponent, {
     path: "generator-history",


### PR DESCRIPTION
History cache from Bitwarden does not work well for the moment with generator. Let's disable it for now, especially since it's not very interesting to remember this page.