### PR TITLE
fix: Add back border bottom in vault in types section

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault-filter.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-filter.component.html
@@ -119,7 +119,7 @@
         <span class="flex-right">4</span>
         -->
       </h2>
-      <div class="box-content single-line">
+      <div class="box-content single-line underline">
         <button
           type="button"
           class="box-content-row"


### PR DESCRIPTION
In a previous commit where I tried to reduce code customization (90c2473dc552db54fec57a96c316bbae6371fa6a), I removed too much and there were no border bottom in vault in types section.