### PR TITLE
fix: Too many items in trash

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault-items.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-items.component.ts
@@ -266,7 +266,7 @@ export class VaultItemsComponent extends BaseVaultItemsComponent implements OnIn
       .subscribe((pageDetails) => (this.pageDetails = pageDetails));
     // Cozy customization end
 
-    super.load(filter);
+    super.load(filter, deleted);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
When overloading load in vault-items.component.ts, I forget to pass the deleted arguments to the parent method. So the deleted filter was not working anymore.