### PR TITLE
fix: Update identity wording

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1648,7 +1648,7 @@
     "message": "Show autofill suggestions on form fields"
   },
   "showInlineMenuIdentitiesLabel": {
-    "message": "Display identities as suggestions"
+    "message": "Display contacts as suggestions"
   },
   "showInlineMenuCardsLabel": {
     "message": "Display cards as suggestions"

--- a/apps/browser/src/_locales/fr/messages.json
+++ b/apps/browser/src/_locales/fr/messages.json
@@ -1642,7 +1642,7 @@
     "message": "Afficher les suggestions de saisie automatique dans les champs d'un formulaire"
   },
   "showInlineMenuIdentitiesLabel": {
-    "message": "Afficher les identités sous forme de suggestions"
+    "message": "Afficher les contacts sous forme de suggestions"
   },
   "showInlineMenuCardsLabel": {
     "message": "Afficher les cartes de paiement sous forme de suggestions"


### PR DESCRIPTION
Last merge upstream added an option to enable or disable identity and card in inline menu. It works out of the box for Cozy contacts. We just need to update the wording.