### PR TITLE
Fix realtime contact race condition

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -111,11 +111,7 @@ import type { IOCozyContact, IOCozyFile } from "cozy-client/types/types";
 import { nameToColor } from "cozy-ui/transpiled/react/Avatar/helpers";
 import { CozyClientService } from "../../popup/services/cozyClient.service";
 import type { AmbiguousContactFieldName, AvailablePapers } from "src/autofill/types";
-import {
-  COZY_ATTRIBUTES_MAPPING,
-  isPaperAttributesModel,
-  isHealthPaper,
-} from "../../../../../libs/cozy/mapping";
+import { COZY_ATTRIBUTES_MAPPING, isPaperAttributesModel } from "../../../../../libs/cozy/mapping";
 import { createOrUpdateCozyDoctype } from "../../../../../libs/cozy/createOrUpdateCozyDoctype";
 import { getCozyValue, getAllPapersFromContact } from "../../../../../libs/cozy/getCozyValue";
 import _ from "lodash";
@@ -1406,11 +1402,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       On the ambiguous(phone/address/email) form field:
       - Display a menu to select value.
     */
-    const shouldHideHealthPaper =
-      (await this.cozyClientService.getFlagValue("hide.healthTheme.enabled")) &&
-      isHealthPaper(this.focusedFieldData?.fieldQualifier);
-
-    if (isPaperAttributesModel(focusedFieldModel) && !shouldHideHealthPaper) {
+    if (isPaperAttributesModel(focusedFieldModel)) {
       const availablePapers: AvailablePapers[] = (
         await getAllPapersFromContact({
           client,
@@ -1448,13 +1440,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
         fieldHtmlIDToFill,
       });
     } else {
-      // Special case: if we are a paper and there are no ambiguous fields, we arrive here
-      // and we do not want to show the empty list
-      if (isPaperAttributesModel(focusedFieldModel) && shouldHideHealthPaper) {
-        this.fillInlineMenuCipher(message, port);
-        return;
-      }
-
       const value = await getCozyValue({
         client,
         cipher,

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -2185,6 +2185,17 @@ export class OverlayBackground implements OverlayBackgroundInterface {
    * @param sender - The sender of the port message
    */
   private async openInlineMenuOnFilledField(sender: chrome.runtime.MessageSender) {
+    // Cozy customization; open inline menu on focus if it is a contact or a paper even if filled field
+    if (
+      this.focusedFieldData.inlineMenuFillType === CipherType.Contact ||
+      this.focusedFieldData.inlineMenuFillType === CipherType.Paper
+    ) {
+      await this.updateInlineMenuPosition(sender, AutofillOverlayElement.Button);
+      await this.updateInlineMenuPosition(sender, AutofillOverlayElement.List);
+      return;
+    }
+    // Cozy customization end
+
     if (await this.shouldShowSaveLoginInlineMenuList(sender.tab)) {
       await this.updateInlineMenuPosition(sender, AutofillOverlayElement.Button);
       await this.updateInlineMenuPosition(sender, AutofillOverlayElement.List);

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -64,12 +64,12 @@ import { InlineMenuFormFieldData } from "../services/abstractions/autofill-overl
 import {
   AutofillService,
   PageDetail,
-  CozyAutofillOptions,
+  CozyAutofillOptions, // Added by Cozy
 } from "../services/abstractions/autofill.service";
 import { InlineMenuFieldQualificationService } from "../services/abstractions/inline-menu-field-qualifications.service";
 import {
-  ambiguousContactFieldNames,
-  getAmbiguousFieldsContact,
+  ambiguousContactFieldNames, // Added by Cozy
+  getAmbiguousFieldsContact, // Added by Cozy
   generateDomainMatchPatterns,
   generateRandomChars,
   isInvalidResponseStatusCode,
@@ -275,21 +275,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   ) {
     this.initOverlayEventObservables();
   }
-
-  private redirectToCozy = (message: OverlayPortMessage) => {
-    // Interpolate "<id>" in the hash by the id correspond to the inline menu cipher id
-    // Useful to open alice.contacts.mycozy.cloud/#/127950390436f45accdf242cac55a2e4/edit for example
-    if (message.inlineMenuCipherId) {
-      const cipher = this.inlineMenuCiphers.get(message.inlineMenuCipherId);
-      message.hash = message.hash.replace("<id>", cipher.id);
-    }
-
-    BrowserApi.createNewTab(this.cozyClientService.getAppURL(message.to, message.hash), true);
-  };
-
-  private searchContacts = (message: OverlayPortMessage) => {
-    this.updateOverlayCiphers(undefined, undefined, message.searchValue);
-  };
 
   /**
    * Sets up the extension message listeners and gets the settings for the
@@ -1307,6 +1292,23 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     this.inlineMenuCiphers = new Map([[inlineMenuCipherId, cipher], ...this.inlineMenuCiphers]);
   }
 
+  // ### Cozy methods ###
+
+  private redirectToCozy = (message: OverlayPortMessage) => {
+    // Interpolate "<id>" in the hash by the id correspond to the inline menu cipher id
+    // Useful to open alice.contacts.mycozy.cloud/#/127950390436f45accdf242cac55a2e4/edit for example
+    if (message.inlineMenuCipherId) {
+      const cipher = this.inlineMenuCiphers.get(message.inlineMenuCipherId);
+      message.hash = message.hash.replace("<id>", cipher.id);
+    }
+
+    BrowserApi.createNewTab(this.cozyClientService.getAppURL(message.to, message.hash), true);
+  };
+
+  private searchContacts = (message: OverlayPortMessage) => {
+    this.updateOverlayCiphers(undefined, undefined, message.searchValue);
+  };
+
   /**
    * Sets the most recently used cipher at the top of the list of ciphers.
    * If the contact doesn't have a Name AND has several ambiguity(tel|email|address), we call `emptyNameList` after selecting the ambiguity.
@@ -1526,6 +1528,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       });
     }
   }
+
+  // ### Cozy methods end ###
 
   /**
    * Checks if the inline menu is focused. Will check the inline menu list

--- a/apps/browser/src/cozy/realtime/synchronousJobQueue.spec.ts
+++ b/apps/browser/src/cozy/realtime/synchronousJobQueue.spec.ts
@@ -1,0 +1,71 @@
+import { SynchronousJobQueue } from "./synchronousJobQueue";
+
+const flushPromises = () => new Promise(jest.requireActual("timers").setImmediate);
+
+const callback = jest.fn();
+
+const resolveAfter100Ms = jest.fn().mockImplementation(() => {
+  callback("100Ms start");
+  return new Promise<void>((resolve) => {
+    setTimeout(function () {
+      callback("100Ms end");
+      resolve();
+    }, 100);
+  });
+});
+
+const resolveAfter500Ms = jest.fn().mockImplementation(() => {
+  callback("500Ms start");
+  return new Promise<void>((resolve) => {
+    setTimeout(function () {
+      callback("500Ms end");
+      resolve();
+    }, 500);
+  });
+});
+
+describe("SynchronousJobQueue", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("should execute job synchronously with SynchronousJobQueue", async () => {
+    const synchronousJobQueue = new SynchronousJobQueue();
+    synchronousJobQueue.push({
+      function: resolveAfter500Ms,
+      arguments: [],
+    });
+    synchronousJobQueue.push({
+      function: resolveAfter100Ms,
+      arguments: [],
+    });
+
+    jest.runAllTimers();
+    await flushPromises();
+    jest.runAllTimers();
+    await flushPromises();
+
+    const expectedCallbackOrder = [["500Ms start"], ["500Ms end"], ["100Ms start"], ["100Ms end"]];
+
+    expect(callback.mock.calls).toEqual(expectedCallbackOrder);
+  });
+
+  it("should execute job asynchronously without SynchronousJobQueue", async () => {
+    resolveAfter500Ms();
+    resolveAfter100Ms();
+
+    jest.runAllTimers();
+    await flushPromises();
+    jest.runAllTimers();
+    await flushPromises();
+
+    const expectedCallbackOrder = [["500Ms start"], ["100Ms start"], ["100Ms end"], ["500Ms end"]];
+
+    expect(callback.mock.calls).toEqual(expectedCallbackOrder);
+  });
+});

--- a/apps/browser/src/cozy/realtime/synchronousJobQueue.ts
+++ b/apps/browser/src/cozy/realtime/synchronousJobQueue.ts
@@ -1,0 +1,35 @@
+interface Job {
+  function: (...args: any[]) => Promise<void>;
+  arguments: any[];
+}
+
+export class SynchronousJobQueue {
+  private isRunning: boolean;
+  private queue: Job[];
+  private onDone: () => void;
+
+  constructor({ onDone }: { onDone?: () => void } = {}) {
+    this.isRunning = false;
+    this.queue = [];
+    this.onDone = onDone;
+  }
+
+  push(job: Job) {
+    this.queue.push(job);
+    if (!this.isRunning) {
+      this.run();
+    }
+  }
+
+  async run() {
+    this.isRunning = true;
+    while (this.queue.length > 0) {
+      const job = this.queue.shift();
+      await job.function(job.arguments);
+    }
+    this.isRunning = false;
+    if (this.onDone) {
+      this.onDone();
+    }
+  }
+}

--- a/libs/cozy/mapping.ts
+++ b/libs/cozy/mapping.ts
@@ -33,9 +33,6 @@ export const isPaperAttributesModel = (
 ): model is PaperAttributesModel => {
   return model.doctype === FILES_DOCTYPE;
 };
-export const isHealthPaper = (fieldQualifier: AutofillFieldQualifierType): boolean => {
-  return fieldQualifier === AutofillFieldQualifier.paperSocialSecurityNumber;
-};
 export const areContactAttributesModels = (
   model: CozyAttributesModel[],
 ): model is ContactAttributesModel[] => {


### PR DESCRIPTION
If on Cozy Contacts, I set 4 contacts as favorite in the same time, it will send 4 contact update events very quickly to the extension. The extension did not handle the events correctly so we could have race condition where we added only part of the favorite contacts to the extension.

So we add a synchronous queue that receive events and manage them sequentially.