### PR TITLE
fix: Autologin in Cozy Pass Web in Chrome

### DIFF
--- a/apps/browser/src/manifest.v3.json
+++ b/apps/browser/src/manifest.v3.json
@@ -36,6 +36,12 @@
       "js": ["content/lp-fileless-importer.js"],
       "matches": ["https://lastpass.com/export.php"],
       "run_at": "document_start"
+    },
+    {
+      "all_frames": true,
+      "js": ["content/appInfo.js"],
+      "matches": ["http://*/*", "https://*/*", "file:///*"],
+      "run_at": "document_start"
     }
   ],
   "background": {


### PR DESCRIPTION
We forgot to add the appInfo script that perform the autologin in Cozy Pass Web in the manifest.v3 so it was not working on Chrome.