### PR TITLE
fix: Do not regenerate passwords on every overlay ciphers update

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -414,8 +414,6 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     this.inlineMenuFido2Credentials.clear();
     this.storeInlineMenuFido2Credentials$.next(currentTab.id);
 
-    await this.generatePassword();
-
     const ciphersViews = await this.getCipherViews(currentTab, updateAllCipherTypes);
     for (let cipherIndex = 0; cipherIndex < ciphersViews.length; cipherIndex++) {
       this.inlineMenuCiphers.set(`inline-menu-cipher-${cipherIndex}`, ciphersViews[cipherIndex]);


### PR DESCRIPTION
This call is causing the password generation to fire as a side-effect of any user interaction in the page so we got flooded by generated password in the history.