### PR TITLE
fix: Open inline menu on focus if filled field only if settings is corresponding

### DIFF
--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -2174,8 +2174,9 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   private async openInlineMenuOnFilledField(sender: chrome.runtime.MessageSender) {
     // Cozy customization; open inline menu on focus if it is a contact or a paper even if filled field
     if (
-      this.focusedFieldData.inlineMenuFillType === CipherType.Contact ||
-      this.focusedFieldData.inlineMenuFillType === CipherType.Paper
+      (this.focusedFieldData.inlineMenuFillType === CipherType.Contact ||
+        this.focusedFieldData.inlineMenuFillType === CipherType.Paper) &&
+      (await this.getInlineMenuVisibility()) === AutofillOverlayVisibility.OnFieldFocus
     ) {
       await this.updateInlineMenuPosition(sender, AutofillOverlayElement.Button);
       await this.updateInlineMenuPosition(sender, AutofillOverlayElement.List);


### PR DESCRIPTION
We customized the inline menu to open it on focus even if the field is filled. But we want to have this behavior only if the inline menu visibility is set to "On focus". If the inline menu visibility is set to "On button click" we want to keep the classic behavior.