### PR TITLE
fix: OIDC login success page not loaded correctly in Firefox

### DIFF
--- a/apps/browser/src/auth/popup/home.component.ts
+++ b/apps/browser/src/auth/popup/home.component.ts
@@ -14,7 +14,7 @@ import { ToastService } from "@bitwarden/components";
 import { BrowserApi } from "../../platform/browser/browser-api";
 import { CozySanitizeUrlService } from "../../popup/services/cozySanitizeUrl.service";
 import { AccountSwitcherService } from "./account-switching/services/account-switcher.service";
-import { getLoginSuccessPageUri, extractDomain } from "../../../src/cozy/sso/helpers";
+import { LOGIN_SUCCESS_PAGE_PATH, extractDomain } from "../../../src/cozy/sso/helpers";
 /* eslint-enable */
 /* end Cozy imports */
 
@@ -179,8 +179,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   /* Cozy custo */
   openTwakeLogin() {
-    const extensionUri = this.platformUtilsService.getExtensionUri();
-    const redirectUri = getLoginSuccessPageUri(extensionUri);
+    const redirectUri = chrome.runtime.getURL(LOGIN_SUCCESS_PAGE_PATH);
 
     BrowserApi.createNewTab(
       `${this.baseUri}/oidc/bitwarden/${this.baseContext}?redirect_uri=${redirectUri}`,
@@ -226,8 +225,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         throw new Error();
       }
 
-      const extensionUri = this.platformUtilsService.getExtensionUri();
-      const redirectUri = getLoginSuccessPageUri(extensionUri);
+      const redirectUri = chrome.runtime.getURL(LOGIN_SUCCESS_PAGE_PATH);
 
       const uriFromWellKnown = await this.fetchLoginUriWithWellKnown(domain);
 
@@ -294,8 +292,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   // Cozy customization
   async redirectIfSSOLoginSuccessTab() {
     chrome.tabs.query({}, (tabs) => {
-      const extensionUri = this.platformUtilsService.getExtensionUri();
-      const redirectUri = getLoginSuccessPageUri(extensionUri);
+      const redirectUri = chrome.runtime.getURL(LOGIN_SUCCESS_PAGE_PATH);
 
       const SSOLoginSuccessTab = tabs.find(
         (tab) => tab.status === "complete" && tab.url.startsWith(redirectUri),

--- a/apps/browser/src/cozy/sso/helpers.ts
+++ b/apps/browser/src/cozy/sso/helpers.ts
@@ -1,6 +1,4 @@
-export const getLoginSuccessPageUri = (extensionUri: string) => {
-  return `${extensionUri}/content/oidcSuccess.html`;
-};
+export const LOGIN_SUCCESS_PAGE_PATH = "/content/oidcSuccess.html";
 
 export const extractDomain = (companyEmail: string): string | null => {
   if (!companyEmail) {

--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
@@ -338,16 +338,4 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
 
     return "";
   }
-
-  // Cozy customization
-  getExtensionUri(): string {
-    if (this.isFirefox()) {
-      return `moz-extension://${chrome.runtime.id}`;
-    } else if (this.isChrome) {
-      return `chrome-extension://${chrome.runtime.id}`;
-    }
-
-    return null;
-  }
-  // Cozy customization end
 }

--- a/libs/common/src/platform/abstractions/platform-utils.service.ts
+++ b/libs/common/src/platform/abstractions/platform-utils.service.ts
@@ -45,7 +45,4 @@ export abstract class PlatformUtilsService {
   abstract readFromClipboard(): Promise<string>;
   abstract supportsSecureStorage(): boolean;
   abstract getAutofillKeyboardShortcut(): Promise<string>;
-  // Cozy customization
-  abstract getExtensionUri(): string;
-  // Cozy customization end
 }


### PR DESCRIPTION
The redirect_uri was not correctly set to the login success page in Firefox. Now instead of building the URL manually, we use a standardized API that build a URL for a resource packaged with the extension.

Support:
- Chrome 22
- Firefox 45